### PR TITLE
feat(tutorial): add "COS Lite on Canonical K8s"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install -r .sphinx/requirements.txt
 Build and serve the docs locally:
 
 ```bash
-make run
+make serve
 ```
 
 

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -31,6 +31,7 @@ fonts
 FQDN
 freefont
 gb
+Gi
 github
 GitOps
 GPG
@@ -38,6 +39,7 @@ grafana
 Grafana's
 gRPCs
 gyre
+hostPath
 https
 HTTPS
 instantiation

--- a/docs/tutorial/installation/cos-lite-canonical-k8s-sandbox.conf
+++ b/docs/tutorial/installation/cos-lite-canonical-k8s-sandbox.conf
@@ -1,0 +1,34 @@
+#cloud-config
+
+# Usage example:
+#   multipass launch noble --cloud-init ./cos-lite-canonical-k8s-sandbox.conf --name cos --memory 8G --cpus 4 --disk 40G
+#   multipass exec cos -- tail -f /var/log/cloud-init-output.log
+
+snap:
+  commands:
+  - snap install juju --channel=3.6/stable
+  - snap install k8s --classic --channel=1.33-classic/stable
+
+runcmd:
+  - |
+    echo "Setting up K8s...""
+    k8s bootstrap
+    k8s status --wait-ready
+    k8s enable local-storage
+    k8s enable load-balancer
+    k8s set load-balancer.l2-mode=true load-balancer.cidrs="$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')/32"
+    k8s status --wait-ready
+
+    echo "Adding K8s cloud to Juju..."
+    k8s kubectl config view --raw | /snap/juju/current/bin/juju add-k8s ck8s --client
+    echo "Bootstrapping K8s controller..."
+    sudo -u ubuntu juju bootstrap ck8s
+
+    echo "Deploying COS Lite..."
+    sudo -u ubuntu juju add-model cos
+    sudo -u ubuntu curl -o ~ubuntu/offers-overlay.yaml -fL https://raw.githubusercontent.com/canonical/cos-lite-bundle/main/overlays/offers-overlay.yaml
+    sudo -u ubuntu juju deploy cos-lite --trust --overlay ~ubuntu/offers-overlay.yaml
+    echo "Waiting for model to settle..."
+    sudo -u ubuntu juju wait-for model cos --query='forEach(units, unit => unit.agent-status == "idle") && forEach(applications, app => app.status == "active")' --timeout=10m
+
+final_message: "The COS Lite appliance is ready, after $UPTIME seconds"

--- a/docs/tutorial/installation/cos-lite-canonical-k8s-sandbox.conf
+++ b/docs/tutorial/installation/cos-lite-canonical-k8s-sandbox.conf
@@ -20,7 +20,7 @@ runcmd:
     k8s status --wait-ready
 
     echo "Adding K8s cloud to Juju..."
-    k8s kubectl config view --raw | /snap/juju/current/bin/juju add-k8s ck8s --client
+    k8s kubectl config view --raw | sudo -u ubuntu /snap/juju/current/bin/juju add-k8s ck8s --client
     echo "Bootstrapping K8s controller..."
     sudo -u ubuntu juju bootstrap ck8s
 

--- a/docs/tutorial/installation/cos-lite-canonical-k8s-sandbox.md
+++ b/docs/tutorial/installation/cos-lite-canonical-k8s-sandbox.md
@@ -2,6 +2,8 @@
 
 In this tutorial you deploy a single-node COS Lite appliance, backed by hostPath storage.
 
+You can reproduce the entire tutorial with a [cloud-config](cos-lite-canonical-k8s-sandbox.conf) script.
+
 ## Prerequisites
 - A 4cpu8gb node or better, with at least 40Gi disk space.
 - Juju v3.6 installed ([doc](https://documentation.ubuntu.com/juju/3.6/howto/manage-juju/#install-juju)).
@@ -123,5 +125,3 @@ loki-logging                     loki          loki-k8s          190  0/0       
 prometheus-receive-remote-write  prometheus    prometheus-k8s    234  0/0        receive-remote-write  prometheus_remote_write  provider
 ```
 
-## Reproducer
-You can reproduce the entire tutorial with a :download:`cloud-config <cos-lite-canonical-k8s-sandbox.conf>` script.

--- a/docs/tutorial/installation/cos-lite-canonical-k8s-sandbox.md
+++ b/docs/tutorial/installation/cos-lite-canonical-k8s-sandbox.md
@@ -1,0 +1,123 @@
+# Getting started with COS Lite on Canonical K8s
+
+## Prerequisites
+- A 4cpu8gb node or better, with at least 40Gi disk space.
+- Juju v3.6 installed ([doc](https://documentation.ubuntu.com/juju/3.6/howto/manage-juju/#install-juju)).
+- Canonical K8s (snap) installed, with local-storage ([doc](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/tutorial/getting-started/))
+  and load-balancer ([doc](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/networking/default-loadbalancer/)) enabled.
+- Proxy ([doc](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/networking/proxy/)) and
+  DNS ([doc](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/networking/default-dns/)) for K8s are configured (if applicable).
+- K8s cloud added to Juju ([doc](https://documentation.ubuntu.com/juju/3.6/howto/manage-clouds/#add-a-kubernetes-cloud)).
+
+
+## Deploy the COS Lite bundle
+
+It is usually a good idea to create a dedicated model for the COS Lite bundle. So let's do just that and call the new model `cos`:
+
+Create a new juju model, `cos`:
+
+```bash
+$ juju add-model cos
+```
+
+Next, deploy the bundle with:
+
+```bash
+$ juju deploy cos-lite --trust
+```
+
+You can watch the model as it settles with:
+
+```bash
+$ juju status --relations --watch=5s
+```
+
+The status of your deployment should eventually be very similar to the following:
+
+```
+$ juju status --relations --storage
+Model  Controller  Cloud/Region  Version  SLA          Timestamp
+cos    ck8s        ck8s          3.6.6    unsupported  16:44:44-04:00
+
+App           Version  Status  Scale  Charm             Channel        Rev  Address         Exposed  Message
+alertmanager  0.27.0   active      1  alertmanager-k8s  1/stable       160  10.152.183.253  no       
+catalogue              active      1  catalogue-k8s     1/stable        81  10.152.183.181  no       
+grafana       9.5.3    active      1  grafana-k8s       1/stable       143  10.152.183.152  no       
+loki          2.9.6    active      1  loki-k8s          1/stable       190  10.152.183.176  no       
+prometheus    2.52.0   active      1  prometheus-k8s    latest/stable  234  10.152.183.54   no       
+traefik       2.11.0   active      1  traefik-k8s       latest/stable  236  10.152.183.56   no       Serving at 10.63.93.172
+
+Unit             Workload  Agent  Address     Ports  Message
+alertmanager/0*  active    idle   10.1.0.221         
+catalogue/0*     active    idle   10.1.0.225         
+grafana/0*       active    idle   10.1.0.129         
+loki/0*          active    idle   10.1.0.72          
+prometheus/0*    active    idle   10.1.0.60          
+traefik/0*       active    idle   10.1.0.65          Serving at 10.63.93.172
+
+Integration provider                Requirer                     Interface              Type     Message
+alertmanager:alerting               loki:alertmanager            alertmanager_dispatch  regular  
+alertmanager:alerting               prometheus:alertmanager      alertmanager_dispatch  regular  
+alertmanager:grafana-dashboard      grafana:grafana-dashboard    grafana_dashboard      regular  
+alertmanager:grafana-source         grafana:grafana-source       grafana_datasource     regular  
+alertmanager:replicas               alertmanager:replicas        alertmanager_replica   peer     
+alertmanager:self-metrics-endpoint  prometheus:metrics-endpoint  prometheus_scrape      regular  
+catalogue:catalogue                 alertmanager:catalogue       catalogue              regular  
+catalogue:catalogue                 grafana:catalogue            catalogue              regular  
+catalogue:catalogue                 prometheus:catalogue         catalogue              regular  
+catalogue:replicas                  catalogue:replicas           catalogue_replica      peer     
+grafana:grafana                     grafana:grafana              grafana_peers          peer     
+grafana:metrics-endpoint            prometheus:metrics-endpoint  prometheus_scrape      regular  
+grafana:replicas                    grafana:replicas             grafana_replicas       peer     
+loki:grafana-dashboard              grafana:grafana-dashboard    grafana_dashboard      regular  
+loki:grafana-source                 grafana:grafana-source       grafana_datasource     regular  
+loki:metrics-endpoint               prometheus:metrics-endpoint  prometheus_scrape      regular  
+loki:replicas                       loki:replicas                loki_replica           peer     
+prometheus:grafana-dashboard        grafana:grafana-dashboard    grafana_dashboard      regular  
+prometheus:grafana-source           grafana:grafana-source       grafana_datasource     regular  
+prometheus:prometheus-peers         prometheus:prometheus-peers  prometheus_peers       peer     
+traefik:ingress                     alertmanager:ingress         ingress                regular  
+traefik:ingress                     catalogue:ingress            ingress                regular  
+traefik:ingress-per-unit            loki:ingress                 ingress_per_unit       regular  
+traefik:ingress-per-unit            prometheus:ingress           ingress_per_unit       regular  
+traefik:metrics-endpoint            prometheus:metrics-endpoint  prometheus_scrape      regular  
+traefik:peers                       traefik:peers                traefik_peers          peer     
+traefik:traefik-route               grafana:ingress              traefik_route          regular  
+
+Storage Unit    Storage ID                Type        Pool        Mountpoint                                      Size     Status    Message
+alertmanager/0  data/0                    filesystem  kubernetes  /var/lib/juju/storage/data/0                    1.0 GiB  attached  Successfully provisioned volume pvc-eb1dc923-32a0-4729-9ec8-694b50672987
+grafana/0       database/1                filesystem  kubernetes  /var/lib/juju/storage/database/0                1.0 GiB  attached  Successfully provisioned volume pvc-b5df8210-671a-4ed6-a083-3fe50e3c6fdc
+loki/0          active-index-directory/2  filesystem  kubernetes  /var/lib/juju/storage/active-index-directory/0  1.0 GiB  attached  Successfully provisioned volume pvc-af183528-4399-42c2-ae59-94e71e1a18c9
+loki/0          loki-chunks/3             filesystem  kubernetes  /var/lib/juju/storage/loki-chunks/0             1.0 GiB  attached  Successfully provisioned volume pvc-86caedeb-e0a5-438f-9ab9-d118f5629723
+prometheus/0    database/4                filesystem  kubernetes  /var/lib/juju/storage/database/0                1.0 GiB  attached  Successfully provisioned volume pvc-eaece84a-5b45-4f08-b82f-5eb07163d637
+traefik/0       configurations/5          filesystem  kubernetes  /var/lib/juju/storage/configurations/0          1.0 GiB  attached  Successfully provisioned volume pvc-4b1da33c-e66f-42bf-a12f-4ac11806a63a
+```
+
+Now COS Lite is good to go: you can relate software with it to begin the monitoring!
+
+## Add "offers" to enable cross-model relations
+
+Download the [offers](https://github.com/canonical/cos-lite-bundle/blob/main/overlays/offers-overlay.yaml)
+[overlay](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/bundle-yaml-file/),
+
+```bash
+curl -L https://raw.githubusercontent.com/canonical/cos-lite-bundle/main/overlays/offers-overlay.yaml -O
+```
+
+ and update the deployment:
+
+```bash
+juju deploy cos-lite --trust --overlay ./offers-overlay.yaml
+```
+
+This enables [cross-model relations](https://documentation.ubuntu.com/juju/3.6/reference/relation/#cross-model).
+In the output of `juju status` you should now see the following new section:
+
+```
+Offer                            Application   Charm             Rev  Connected  Endpoint              Interface                Role
+alertmanager-karma-dashboard     alertmanager  alertmanager-k8s  160  0/0        karma-dashboard       karma_dashboard          provider
+grafana-dashboards               grafana       grafana-k8s       143  0/0        grafana-dashboard     grafana_dashboard        requirer
+loki-logging                     loki          loki-k8s          190  0/0        logging               loki_push_api            provider
+prometheus-receive-remote-write  prometheus    prometheus-k8s    234  0/0        receive-remote-write  prometheus_remote_write  provider
+```
+

--- a/docs/tutorial/installation/cos-lite-canonical-k8s-sandbox.md
+++ b/docs/tutorial/installation/cos-lite-canonical-k8s-sandbox.md
@@ -1,5 +1,7 @@
 # Getting started with COS Lite on Canonical K8s
 
+In this tutorial you deploy a single-node COS Lite appliance, backed by hostPath storage.
+
 ## Prerequisites
 - A 4cpu8gb node or better, with at least 40Gi disk space.
 - Juju v3.6 installed ([doc](https://documentation.ubuntu.com/juju/3.6/howto/manage-juju/#install-juju)).
@@ -121,3 +123,5 @@ loki-logging                     loki          loki-k8s          190  0/0       
 prometheus-receive-remote-write  prometheus    prometheus-k8s    234  0/0        receive-remote-write  prometheus_remote_write  provider
 ```
 
+## Reproducer
+You can reproduce the entire tutorial with a :download:`cloud-config <cos-lite-canonical-k8s-sandbox.conf>` script.

--- a/docs/tutorial/installation/getting-started-with-cos-lite.md
+++ b/docs/tutorial/installation/getting-started-with-cos-lite.md
@@ -4,7 +4,7 @@
 
 This tutorial assumes you have a Juju controller bootstrapped on a 
 MicroK8s cloud that is ready to use. A typical setup using [snaps](https://snapcraft.io/) 
-can be found in the [Juju docs](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/manage-your-deployment-environment/).
+can be found in the [Juju docs](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/).
 
 Follow the instructions there to install Juju and MicroK8s.
 
@@ -79,7 +79,7 @@ $ juju deploy cos-lite --trust
 Now you can sit back and watch the deployment take place:
 
 ```bash
-$ watch --color juju status --color --relations
+$ juju status --relations --watch=5s
 ```
 
 The status of your deployment should eventually be very similar to the following:

--- a/docs/tutorial/installation/getting-started-with-cos-lite.md
+++ b/docs/tutorial/installation/getting-started-with-cos-lite.md
@@ -1,9 +1,12 @@
 # Getting started with COS Lite on MicroK8s
 
+In this tutorial you deploy a single-node COS Lite appliance, backed by hostPath storage.
+
 ## Prerequisites
 
 This tutorial assumes you have a Juju controller bootstrapped on a 
-MicroK8s cloud that is ready to use. A typical setup using [snaps](https://snapcraft.io/) 
+MicroK8s cloud that is ready to use, on a 4cpu8gb node or better, with at least 40Gi disk space.
+Typical setup using [snaps](https://snapcraft.io/) 
 can be found in the [Juju docs](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/).
 
 Follow the instructions there to install Juju and MicroK8s.

--- a/docs/tutorial/installation/index.rst
+++ b/docs/tutorial/installation/index.rst
@@ -9,21 +9,3 @@ Deploying the observability stack
    A. COS Lite on MicroK8s <getting-started-with-cos-lite>
    B. COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>
 
-
-## Sandbox-grade tutorials
-.. list-table:: Installation tutorials
-   :widths: auto
-   :header-rows: 1
-
-   * - Tutorial
-     - Storage
-     - Resource requirements
-     - Reproducer
-   * - :doc:`COS Lite on MicroK8s <getting-started-with-cos-lite>`
-     - hostPath
-     - 4cpu8gb
-     - 
-   * - :doc:`COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>`
-     - hostPath
-     - 4cpu8gb
-     - :download:`cloud-config <cos-lite-canonical-k8s-sandbox.conf>`

--- a/docs/tutorial/installation/index.rst
+++ b/docs/tutorial/installation/index.rst
@@ -4,7 +4,10 @@ Deploying the observability stack
 *********************************
 
 .. toctree::
-   :maxdepth: 1 
+   :maxdepth: 1
+   
+   A. COS Lite on MicroK8s <getting-started-with-cos-lite>
+   B. COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>
 
 
 .. list-table:: Installation tutorials
@@ -19,16 +22,16 @@ Deploying the observability stack
      - Resource requirements
      - Reproducer
    * - Sandbox
-     - COS Lite on MicroK8s <getting-started-with-cos-lite>
+     - :doc:`COS Lite on MicroK8s <getting-started-with-cos-lite>`
      - COS Lite
      - MicroK8s
      - hostPath
      - 4cpu8gb
      - 
    * - Sandbox
-     - COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>
+     - :doc:`COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>`
      - COS Lite
      - Canonical K8s (snap)
      - hostPath
      - 4cpu8gb
-     - cloud-config <cos-lite-canonical-k8s-sandbox.conf>
+     - :download:`cloud-config <cos-lite-canonical-k8s-sandbox.conf>`

--- a/docs/tutorial/installation/index.rst
+++ b/docs/tutorial/installation/index.rst
@@ -4,6 +4,28 @@ Deploying the observability stack
 *********************************
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 1 
 
-   A. COS Lite on MicroK8s <getting-started-with-cos-lite>
+
+.. list-table:: Installation tutorials
+   :widths: auto
+   :header-rows: 1
+
+   * - Grade
+     - Tutorial
+     - Distribution
+     - Kubernetes
+     - Storage
+     - Resource requirements
+   * - Sandbox
+     - COS Lite on MicroK8s <getting-started-with-cos-lite>
+     - COS Lite
+     - MicroK8s
+     - hostPath
+     - 4cpu8gb
+   * - Sandbox
+     - COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>
+     - COS Lite
+     - Canonical K8s (snap)
+     - hostPath
+     - 4cpu8gb

--- a/docs/tutorial/installation/index.rst
+++ b/docs/tutorial/installation/index.rst
@@ -10,28 +10,20 @@ Deploying the observability stack
    B. COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>
 
 
+## Sandbox-grade tutorials
 .. list-table:: Installation tutorials
    :widths: auto
    :header-rows: 1
 
-   * - Grade
-     - Tutorial
-     - Distribution
-     - Kubernetes
+   * - Tutorial
      - Storage
      - Resource requirements
      - Reproducer
-   * - Sandbox
-     - :doc:`COS Lite on MicroK8s <getting-started-with-cos-lite>`
-     - COS Lite
-     - MicroK8s
+   * - :doc:`COS Lite on MicroK8s <getting-started-with-cos-lite>`
      - hostPath
      - 4cpu8gb
      - 
-   * - Sandbox
-     - :doc:`COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>`
-     - COS Lite
-     - Canonical K8s (snap)
+   * - :doc:`COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>`
      - hostPath
      - 4cpu8gb
      - :download:`cloud-config <cos-lite-canonical-k8s-sandbox.conf>`

--- a/docs/tutorial/installation/index.rst
+++ b/docs/tutorial/installation/index.rst
@@ -17,15 +17,18 @@ Deploying the observability stack
      - Kubernetes
      - Storage
      - Resource requirements
+	 - Reproducer
    * - Sandbox
      - COS Lite on MicroK8s <getting-started-with-cos-lite>
      - COS Lite
      - MicroK8s
      - hostPath
      - 4cpu8gb
+	 - 
    * - Sandbox
      - COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>
      - COS Lite
      - Canonical K8s (snap)
      - hostPath
      - 4cpu8gb
+	 - cloud-config <cos-lite-canonical-k8s-sandbox.conf>

--- a/docs/tutorial/installation/index.rst
+++ b/docs/tutorial/installation/index.rst
@@ -17,18 +17,18 @@ Deploying the observability stack
      - Kubernetes
      - Storage
      - Resource requirements
-	 - Reproducer
+     - Reproducer
    * - Sandbox
      - COS Lite on MicroK8s <getting-started-with-cos-lite>
      - COS Lite
      - MicroK8s
      - hostPath
      - 4cpu8gb
-	 - 
+     - 
    * - Sandbox
      - COS Lite on Canonical K8s <cos-lite-canonical-k8s-sandbox>
      - COS Lite
      - Canonical K8s (snap)
      - hostPath
      - 4cpu8gb
-	 - cloud-config <cos-lite-canonical-k8s-sandbox.conf>
+     - cloud-config <cos-lite-canonical-k8s-sandbox.conf>


### PR DESCRIPTION
In this PR:
- Add a tutorial for deploying cos-lite on canonical k8s. This is a simplification of the microk8s tutorial, massively linking to external documentation. Along the way the following issues were created:
  - https://github.com/canonical/k8s-snap/issues/1501
  - https://github.com/canonical/k8s-snap/issues/1502
  - https://github.com/juju/juju/issues/19903
  - https://github.com/canonical/k8s-snap/issues/1503
  - https://github.com/canonical/k8s-snap/issues/1504
- Restructure tutorials index as a table.
- Add reproducer for tutorial (cloud-init script).