### PR TITLE
fix: Offers and components outputs for COS Lite

### DIFF
--- a/docs/tutorial/installation/cos-canonical-k8s-sandbox.md
+++ b/docs/tutorial/installation/cos-canonical-k8s-sandbox.md
@@ -18,20 +18,7 @@ You can reproduce the COS deployment with a [Terraform module](cos-canonical-k8s
 
 Create a `cos-canonical-k8s-sandbox.tf` file with the following Terraform module, or include it in your Terraform plan:
 
-```
-module "cos" {
-  source                        = "git::https://github.com/canonical/observability-stack//terraform/cos"
-  model_name                    = "cos"
-  channel                       = "1/stable"
-  s3_endpoint                   = "http://{{IPADDR}}:8080"
-  s3_password                   = "secret-key"
-  s3_user                       = "access-key"
-  loki_bucket                   = "loki"
-  mimir_bucket                  = "mimir"
-  tempo_bucket                  = "tempo"
-  ssc_channel                   = "1/stable"
-  anti_affinity                 = true
-}
+```{literalinclude} /tutorial/installation/cos-canonical-k8s-sandbox.tf
 ```
 
 <!-- warn users of the 2 Juju Provider bugs -->

--- a/docs/tutorial/installation/cos-canonical-k8s-sandbox.tf
+++ b/docs/tutorial/installation/cos-canonical-k8s-sandbox.tf
@@ -1,13 +1,14 @@
 module "cos" {
-  source        = "git::https://github.com/canonical/observability-stack//terraform/cos"
-  model         = "cos-2"
-  channel       = "1/stable"
-  s3_endpoint   = "http://192.168.88.12:8080"
-  s3_secret_key = "secret-key"
-  s3_access_key = "access-key"
-  loki_bucket   = "loki"
-  mimir_bucket  = "mimir"
-  tempo_bucket  = "tempo"
-  ssc_channel   = "1/stable"
-  anti_affinity = true
+  source          = "git::https://github.com/canonical/observability-stack//terraform/cos"
+  model           = "cos"
+  channel         = "1/stable"
+  s3_endpoint     = "http://{{IPADDR}}:8080"
+  s3_secret_key   = "secret-key"
+  s3_access_key   = "access-key"
+  loki_bucket     = "loki"
+  mimir_bucket    = "mimir"
+  tempo_bucket    = "tempo"
+  ssc_channel     = "1/stable"
+  traefik_channel = "latest/stable"
+  anti_affinity   = true
 }

--- a/terraform/cos-lite/main.tf
+++ b/terraform/cos-lite/main.tf
@@ -39,14 +39,14 @@ module "ssc" {
   count   = var.use_tls ? 1 : 0
   source  = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
   model   = var.model
-  channel = var.channel
+  channel = var.ssc_channel
 }
 
 module "traefik" {
   source   = "git::https://github.com/canonical/traefik-k8s-operator//terraform"
   app_name = "traefik"
   model    = var.model
-  channel  = var.channel
+  channel  = var.traefik_channel
 }
 
 # -------------- # Integrations --------------

--- a/terraform/cos-lite/outputs.tf
+++ b/terraform/cos-lite/outputs.tf
@@ -1,27 +1,24 @@
-output "app_names" {
-  value = merge(
-    {
-      alertmanager = module.alertmanager.app_name,
-      catalogue    = module.catalogue.app_name,
-      grafana      = module.grafana.app_name,
-      loki         = module.loki.app_name,
-      prometheus   = module.prometheus.app_name,
-      traefik      = module.traefik.app_name,
-    }
-  )
+# -------------- # Integration offers -------------- #
+
+output "offers" {
+  value = {
+    alertmanager_karma_dashboard = juju_offer.alertmanager-karma-dashboard
+    grafana_dashboards           = juju_offer.grafana-dashboards
+    loki_logging                 = juju_offer.loki-logging
+    mimir_receive_remote_write   = juju_offer.mimir-receive-remote-write
+  }
 }
 
-output "grafana" {
-  description = "Outputs from the Grafana module"
-  value       = module.grafana
-}
+# -------------- # Submodules -------------- #
 
-output "prometheus" {
-  description = "Outputs from the prometheus module"
-  value       = module.prometheus
-}
-
-output "loki" {
-  description = "Outputs from the Loki module"
-  value       = module.loki
+output "components" {
+  value = {
+    alertmanager  = module.alertmanager
+    catalogue     = module.catalogue
+    grafana       = module.grafana
+    loki          = module.loki
+    prometheus    = module.prometheus
+    ssc           = module.ssc
+    traefik       = module.traefik
+  }
 }

--- a/terraform/cos-lite/outputs.tf
+++ b/terraform/cos-lite/outputs.tf
@@ -2,10 +2,10 @@
 
 output "offers" {
   value = {
-    alertmanager_karma_dashboard = juju_offer.alertmanager-karma-dashboard
-    grafana_dashboards           = juju_offer.grafana-dashboards
-    loki_logging                 = juju_offer.loki-logging
-    mimir_receive_remote_write   = juju_offer.mimir-receive-remote-write
+    alertmanager_karma_dashboard    = juju_offer.alertmanager-karma-dashboard
+    grafana_dashboards              = juju_offer.grafana-dashboards
+    loki_logging                    = juju_offer.loki-logging
+    prometheus_receive_remote_write = juju_offer.prometheus-receive-remote-write
   }
 }
 
@@ -13,12 +13,12 @@ output "offers" {
 
 output "components" {
   value = {
-    alertmanager  = module.alertmanager
-    catalogue     = module.catalogue
-    grafana       = module.grafana
-    loki          = module.loki
-    prometheus    = module.prometheus
-    ssc           = module.ssc
-    traefik       = module.traefik
+    alertmanager = module.alertmanager
+    catalogue    = module.catalogue
+    grafana      = module.grafana
+    loki         = module.loki
+    prometheus   = module.prometheus
+    ssc          = module.ssc
+    traefik      = module.traefik
   }
 }

--- a/terraform/cos-lite/variables.tf
+++ b/terraform/cos-lite/variables.tf
@@ -1,11 +1,10 @@
 variable "channel" {
-  description = "Charms channel"
+  description = "Channel that the charms are (unless overwritten by external_channels) deployed from"
   type        = string
-  default     = "latest/edge"
 }
 
 variable "model" {
-  description = "Model name"
+  description = "Reference to an existing model resource or data source for the model to deploy to"
   type        = string
 }
 
@@ -13,4 +12,19 @@ variable "use_tls" {
   description = "Specify whether to use TLS or not for coordinator-worker communication. By default, TLS is enabled through self-signed-certificates"
   type        = bool
   default     = true
+}
+
+# -------------- # External channels --------------
+# O11y does not own these charms, so we allow users to specify their channels directly.
+
+variable "ssc_channel" {
+  description = "Channel that the self-signed certificates charm is deployed from"
+  type        = string
+  default     = "1/stable"
+}
+
+variable "traefik_channel" {
+  description = "Channel that the Traefik charm is deployed from"
+  type        = string
+  default     = "latest/stable"
 }


### PR DESCRIPTION
Drive-by fix:
- In-line the TF reference in the `docs/tutorial/installation/cos-canonical-k8s-sandbox.md` doc

Related:
- https://github.com/canonical/observability/issues/308
- https://raw.githubusercontent.com/canonical/cos-lite-bundle/main/overlays/offers-overlay.yaml

Fixes:
- https://github.com/canonical/observability-stack/issues/45