### PR TITLE
feat: COS certificates integrations (e-2-e TLS)

### DIFF
--- a/terraform/cos/main.tf
+++ b/terraform/cos/main.tf
@@ -605,6 +605,128 @@ resource "juju_integration" "grafana_tracing_grafana_agent_traicing_provider" {
   }
 }
 
+# Provided by Self-Signed-Certificates
+
+resource "juju_integration" "alertmanager_certificates" {
+  count = var.use_tls ? 1 : 0
+  model = var.model
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.alertmanager.app_name
+    endpoint = module.alertmanager.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "catalogue_certificates" {
+  count = var.use_tls ? 1 : 0
+  model = var.model
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.catalogue.app_name
+    endpoint = module.catalogue.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "grafana_certificates" {
+  count = var.use_tls ? 1 : 0
+  model = var.model
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "grafana_agent_certificates" {
+  count = var.use_tls ? 1 : 0
+  model = var.model
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.grafana_agent.app_name
+    endpoint = module.grafana_agent.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "loki_certificates" {
+  count = var.use_tls ? 1 : 0
+  model = var.model
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.loki.app_names.loki_coordinator
+    endpoint = module.loki.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "mimir_certificates" {
+  count = var.use_tls ? 1 : 0
+  model = var.model
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.mimir.app_names.mimir_coordinator
+    endpoint = module.mimir.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "tempo_certificates" {
+  count = var.use_tls ? 1 : 0
+  model = var.model
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.tempo.app_names.tempo_coordinator
+    endpoint = module.tempo.endpoints.certificates
+  }
+}
+
+resource "juju_integration" "traefik_certificates" {
+  count = var.use_tls ? 1 : 0
+  model = var.model
+
+  application {
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
+  }
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.endpoints.certificates
+  }
+}
+
 # -------------- # Offers --------------
 
 resource "juju_offer" "alertmanager_karma_dashboard" {


### PR DESCRIPTION
Related to:
- https://github.com/canonical/observability-stack/pull/40

## Deploy with TLS

Create a `observability-stack/terraform/modules/cos/tls.tfvars` file:
```hcl
model           = "tls"
channel         = "2/edge"
ssc_channel     = "1/edge"
traefik_channel = "latest/edge"
use_tls         = true
ssc_revision    = 308  # https://github.com/canonical/traefik-k8s-operator/issues/491#issuecomment-2988139389
```
