### PR TITLE
fix: Breaking 0.20.0 juju provider `juju_offers` `endpoint` -> `endpoints`

### DIFF
--- a/terraform/cos-lite/main.tf
+++ b/terraform/cos-lite/main.tf
@@ -441,26 +441,26 @@ resource "juju_offer" "alertmanager_karma_dashboard" {
   name             = "alertmanager-karma-dashboard"
   model            = var.model
   application_name = module.alertmanager.app_name
-  endpoint         = "karma-dashboard"
+  endpoints        = ["karma-dashboard"]
 }
 
 resource "juju_offer" "grafana_dashboards" {
   name             = "grafana-dashboards"
   model            = var.model
   application_name = module.grafana.app_name
-  endpoint         = "grafana-dashboard"
+  endpoints        = ["grafana-dashboard"]
 }
 
 resource "juju_offer" "loki_logging" {
   name             = "loki-logging"
   model            = var.model
   application_name = module.loki.app_name
-  endpoint         = "logging"
+  endpoints        = ["logging"]
 }
 
 resource "juju_offer" "prometheus_receive_remote_write" {
   name             = "prometheus-receive-remote-write"
   model            = var.model
   application_name = module.prometheus.app_name
-  endpoint         = "receive-remote-write"
+  endpoints        = ["receive-remote-write"]
 }

--- a/terraform/cos-lite/versions.tf
+++ b/terraform/cos-lite/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14"
+      version = ">= 0.20.0"
     }
   }
 }

--- a/terraform/cos/main.tf
+++ b/terraform/cos/main.tf
@@ -611,26 +611,26 @@ resource "juju_offer" "alertmanager_karma_dashboard" {
   name             = "alertmanager-karma-dashboard"
   model            = var.model
   application_name = module.alertmanager.app_name
-  endpoint         = "karma-dashboard"
+  endpoints        = ["karma-dashboard"]
 }
 
 resource "juju_offer" "grafana_dashboards" {
   name             = "grafana-dashboards"
   model            = var.model
   application_name = module.grafana.app_name
-  endpoint         = "grafana-dashboard"
+  endpoints        = ["grafana-dashboard"]
 }
 
 resource "juju_offer" "loki_logging" {
   name             = "loki-logging"
   model            = var.model
   application_name = module.loki.app_names.loki_coordinator
-  endpoint         = "logging"
+  endpoints        = ["logging"]
 }
 
 resource "juju_offer" "mimir_receive_remote_write" {
   name             = "mimir-receive-remote-write"
   model            = var.model
   application_name = module.mimir.app_names.mimir_coordinator
-  endpoint         = "receive-remote-write"
+  endpoints        = ["receive-remote-write"]
 }

--- a/terraform/cos/versions.tf
+++ b/terraform/cos/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.20.0"
     }
   }
 }


### PR DESCRIPTION
This TF [Juju provider commit](https://github.com/juju/terraform-provider-juju/commit/069f7b5cdab2505c21fc23a3fbff5080c66d3344#diff-2c80b268ac3f4cd97227d31e39fe688799eaa3eb017319e1be27c9ea4c49eb81R42) changes the `juju_offer` endpoint attribute to endpoints. We have to bump the TF Juju provider version pin and update the attributes for compatibility.

The expectation is that users wanting to use our product modules will have to now use `>=0.20.0` or pin our product modules to a specific git commit prior to this PR merging.