### PR TITLE
chore: Revert TF sources back to GH from locals

### DIFF
--- a/terraform/cos/applications.tf
+++ b/terraform/cos/applications.tf
@@ -47,8 +47,7 @@ module "grafana_agent" {
 }
 
 module "loki" {
-  # source                 = "git::https://github.com/canonical/observability-stack//terraform/loki"
-  source                           = "../loki" # FIXME
+  source                           = "git::https://github.com/canonical/observability-stack//terraform/loki"
   anti_affinity                    = var.anti_affinity
   channel                          = var.channel
   model                            = var.model
@@ -79,8 +78,7 @@ module "loki" {
 }
 
 module "mimir" {
-  # source                 = "git::https://github.com/canonical/observability-stack//terraform/mimir"
-  source                           = "../mimir" # FIXME
+  source                           = "git::https://github.com/canonical/observability-stack//terraform/mimir"
   anti_affinity                    = var.anti_affinity
   channel                          = var.channel
   model                            = var.model
@@ -123,8 +121,7 @@ module "ssc" {
 }
 
 module "tempo" {
-  # source                  = "git::https://github.com/canonical/observability-stack//terraform/tempo"
-  source                           = "../tempo" # FIXME
+  source                           = "git::https://github.com/canonical/observability-stack//terraform/tempo"
   anti_affinity                    = var.anti_affinity
   channel                          = var.channel
   model                            = var.model


### PR DESCRIPTION
After merging:
- https://github.com/canonical/observability-stack/pull/79

I need to revert the TF sources.