### PR TITLE
fix: Separate channel for Otelcol since we do not yet have a 1/stable

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ lint-terraform:
 # Lint the Terraform documentation
 [group("Lint")]
 lint-terraform-docs:
-  terraform-docs --config .tfdocs-config.yml .
+  terraform-docs --output-check --config .tfdocs-config.yml .
 
 # Format the Terraform modules
 [group("Format")]

--- a/terraform/cos/applications.tf
+++ b/terraform/cos/applications.tf
@@ -99,7 +99,7 @@ module "mimir" {
 module "opentelemetry_collector" {
   source             = "git::https://github.com/canonical/opentelemetry-collector-k8s-operator//terraform"
   app_name           = var.opentelemetry_collector.app_name
-  channel            = var.opentelemetry_collector.channel  # FIXME Remove this once we have a 1/stable
+  channel            = var.opentelemetry_collector.channel # FIXME Remove this once we have a 1/stable
   config             = var.opentelemetry_collector.config
   constraints        = var.opentelemetry_collector.constraints
   model              = var.model

--- a/terraform/cos/applications.tf
+++ b/terraform/cos/applications.tf
@@ -35,7 +35,7 @@ module "grafana" {
 }
 
 module "loki" {
-  source                           = "git::https://github.com/canonical/observability-stack//terraform/loki"
+  source                           = "git::https://github.com/canonical/observability-stack//terraform/loki?ref=fix/otelcol-channel"
   anti_affinity                    = var.anti_affinity
   channel                          = var.channel
   model                            = var.model
@@ -66,7 +66,7 @@ module "loki" {
 }
 
 module "mimir" {
-  source                           = "git::https://github.com/canonical/observability-stack//terraform/mimir"
+  source                           = "git::https://github.com/canonical/observability-stack//terraform/mimir?ref=fix/otelcol-channel"
   anti_affinity                    = var.anti_affinity
   channel                          = var.channel
   model                            = var.model
@@ -99,7 +99,7 @@ module "mimir" {
 module "opentelemetry_collector" {
   source             = "git::https://github.com/canonical/opentelemetry-collector-k8s-operator//terraform"
   app_name           = var.opentelemetry_collector.app_name
-  channel            = var.channel
+  channel            = var.opentelemetry_collector.channel  # FIXME Remove this once we have a 1/stable
   config             = var.opentelemetry_collector.config
   constraints        = var.opentelemetry_collector.constraints
   model              = var.model
@@ -121,7 +121,7 @@ module "ssc" {
 }
 
 module "tempo" {
-  source                           = "git::https://github.com/canonical/observability-stack//terraform/tempo"
+  source                           = "git::https://github.com/canonical/observability-stack//terraform/tempo?ref=fix/otelcol-channel"
   anti_affinity                    = var.anti_affinity
   channel                          = var.channel
   model                            = var.model

--- a/terraform/cos/variables.tf
+++ b/terraform/cos/variables.tf
@@ -185,6 +185,7 @@ variable "mimir_worker" {
 variable "opentelemetry_collector" {
   type = object({
     app_name           = optional(string, "otelcol")
+    channel            = optional(string, "2/edge")  # FIXME Remove this once we have a 1/stable
     config             = optional(map(string), {})
     constraints        = optional(string, "arch=amd64")
     revision           = optional(number, null)

--- a/terraform/cos/variables.tf
+++ b/terraform/cos/variables.tf
@@ -185,7 +185,7 @@ variable "mimir_worker" {
 variable "opentelemetry_collector" {
   type = object({
     app_name           = optional(string, "otelcol")
-    channel            = optional(string, "2/edge")  # FIXME Remove this once we have a 1/stable
+    channel            = optional(string, "2/edge") # FIXME Remove this once we have a 1/stable
     config             = optional(map(string), {})
     constraints        = optional(string, "arch=amd64")
     revision           = optional(number, null)


### PR DESCRIPTION
This allows users to still set `1/stable` for most charm channels that O11y owns, with Otelcol being the exception until it is no longer in rapid development, i.e. a `1/stable` channel.

Future looking issue to revert this separation of channel variables for O11y charms:
- https://github.com/canonical/observability-stack/issues/91

> [!IMPORTANT]
> I will fix the terraform-docs CI once I can revert the pin for the module source back to main versus this branch on merging. The important part is that `validate-terraform` is passing.

## Usage

```diff
module "cos" {
  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos" # 21/Jul/2025
  model  = "cos"
  channel                         = "1/stable"
  anti_affinity                   = false
  internal_tls                    = false
  external_certificates_offer_url = null
  s3_endpoint                     = "http//S3_IP:8080"
  s3_secret_key                   = "secret-key"
  s3_access_key                   = "access-key"
  loki_bucket                     = "loki"
  mimir_bucket                    = "mimir"
  tempo_bucket                    = "tempo"
  s3_integrator                   = { channel = "2/edge", revision = 157 } # FIXME: https://github.com/canonical/observability/issues/342
+  opentelemetry_collector         = { channel = "2/edge" }
  loki_coordinator                = { units = 1 }
  loki_worker                     = { backend_units = 1, read_units = 1, write_units = 1 }
  mimir_coordinator               = { units = 1 }
  mimir_worker                    = { backend_units = 1, read_units = 1, write_units = 1 }
  tempo_coordinator               = { units = 1 }
  tempo_worker                    = { compactor_units = 1, distributor_units = 1, ingester_units = 1, metrics_generator_units = 1, querier_units = 1, query_frontend_units = 1 }
  ssc                             = { channel = "1/stable" }
  traefik                         = { channel = "latest/stable" }
}
```