### PR TITLE
chore: Change manual bucket creation references in docs

### DIFF
--- a/docs/how-to/deploy-s3-integrator-and-minio.md
+++ b/docs/how-to/deploy-s3-integrator-and-minio.md
@@ -61,6 +61,10 @@ $ juju run s3/leader sync-s3-credentials \
 
 ### 3. Add a bucket
 
+#### Through s3-integrator
+
+As of `rev243+` of `s3-integrator`, the integrator will create the requested bucket as part of the startup procedure. You don't need to create the buckets manually anymore.
+
 #### Using the Minio UI
 
 The simplest way to create a bucket is to use the Minio console UI. Obtain the Minio IP from the `juju status` output and then open `http://MINIO_IP:9001` in a browser using the `access-key` and `secret-key` you configured earlier as user and password respectively.

--- a/docs/tutorial/installation/cos-canonical-k8s-sandbox.conf
+++ b/docs/tutorial/installation/cos-canonical-k8s-sandbox.conf
@@ -34,18 +34,6 @@ runcmd:
     microceph.radosgw-admin key create --uid=user --key-type=s3 --access-key=access-key --secret-key=secret-key
     # [docs:setup-s3-end]
 
-    # Create buckets for COS
-    # [docs:create-buckets]
-    for BUCKET in loki mimir tempo; do
-      s3cmd --host=$IPADDR:8080 \
-        --access_key=access-key \
-        --secret_key=secret-key \
-        --host-bucket= \
-        --no-ssl \
-        mb s3://$BUCKET
-    done
-    # [docs:create-buckets-end]
-
     echo "Setting up K8s..."
     # Adjust system defaults to avoid "failed to create fsnotify watcher: too many open files"
     # https://github.com/canonical/k8s-snap/pull/1619

--- a/docs/tutorial/installation/cos-canonical-k8s-sandbox.md
+++ b/docs/tutorial/installation/cos-canonical-k8s-sandbox.md
@@ -27,15 +27,6 @@ and configure RadosGW to listen on port 8080 ([doc](https://canonical-microceph.
     :dedent: 4
 ```
 
-### Create buckets for Loki, Mimir and Tempo
-
-```{literalinclude} /tutorial/installation/cos-canonical-k8s-sandbox.conf
-    :language: bash
-    :start-after: [docs:create-buckets]
-    :end-before: [docs:create-buckets-end]
-    :dedent: 4
-```
-
 ## Deploy COS using Terraform
 
 Assuming you are using the username `ubuntu`, create a `cos-demo.tf` file as follows:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
After #118, users don't need to create buckets themselves anymore.

## Solution
<!-- A summary of the solution addressing the above issue -->
Stop suggesting bucket creation in most cases. Where people might still use  the older `s3-integrator`, the reference stayed, but a comment on new automatic bucket creation was added.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
