### PR TITLE
fix: source the Tempo submodule with a fixed tag

### DIFF
--- a/terraform/cos/applications.tf
+++ b/terraform/cos/applications.tf
@@ -128,8 +128,9 @@ module "ssc" {
   units       = var.ssc.units
 }
 
+
 module "tempo" {
-  source                           = "git::https://github.com/canonical/tempo-operators//terraform?ref=tf-provider-v0-fixed"
+  source                           = "git::https://github.com/canonical/tempo-operators//terraform?ref=tf-provider-v0"
   anti_affinity                    = var.anti_affinity
   channel                          = var.channel
   model                            = var.model


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The Tempo TF module was being sourced from `tf-provider-v0` which was not correctly sourcing the submodules from the same tag.

## Solution
<!-- A summary of the solution addressing the above issue -->
Source the TF module from `tf-provider-v0-fixed` which is a tag that fixes this scenario.