### PR TITLE
fix: COS installation docs

### DIFF
--- a/docs/tutorial/installation/cos-canonical-k8s-sandbox.conf
+++ b/docs/tutorial/installation/cos-canonical-k8s-sandbox.conf
@@ -58,9 +58,24 @@ runcmd:
     # [docs:create-terraform-module]
     sudo -u ubuntu mkdir ~ubuntu/cos
     sudo -u ubuntu tee ~ubuntu/cos/cos-demo.tf << EOF 
+    terraform {
+      required_version = ">= 1.5"
+      required_providers {
+        juju = {
+          source  = "juju/juju"
+          version = "~> 1.0"
+        }
+      }
+    }
+
+    data "juju_model" "my-model" {
+      name  = "cos"
+      owner = "admin"
+    }
+    
     module "cos" {
-      source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=54108f1e5a5fa4eadc71066f4d5248fd83df6099"  # 21/Jul/2025
-      model                           = "cos"
+      source                          = "git::https://github.com/canonical/observability-stack//terraform/cos"
+      model_uuid                      = data.juju_model.my-model.uuid
       channel                         = "2/edge"
       anti_affinity                   = false
       internal_tls                    = false
@@ -68,10 +83,6 @@ runcmd:
       s3_endpoint                     = "http://$IPADDR:8080"
       s3_secret_key                   = "secret-key"
       s3_access_key                   = "access-key"
-      loki_bucket                     = "loki"
-      mimir_bucket                    = "mimir"
-      tempo_bucket                    = "tempo"
-      s3_integrator                   = { channel = "2/edge", revision = 157 }  # FIXME: https://github.com/canonical/observability/issues/342
       ssc                             = { channel = "1/stable" }
       traefik                         = { channel = "latest/stable" }
     }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
With the merger of:
- https://github.com/canonical/observability-stack/pull/139

The installation docs are out of date due to a pin which references floating submodules. Additionally, it is missing the `required_providers` and `juju_model` definitions.

## Solution
<!-- A summary of the solution addressing the above issue -->
Update the TF module in the tutorial so it is a working solution.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
```hcl
terraform {
  required_version = ">= 1.5"
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "~> 1.0"
    }
  }
}

data "juju_model" "my-model" {
  name  = "cos"
  owner = "admin"
}

module "cos" {
  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos"
  model_uuid                      = data.juju_model.my-model.uuid
  channel                         = "2/edge"
  anti_affinity                   = false
  internal_tls                    = false
  external_certificates_offer_url = null
  s3_endpoint                     = "http://$IPADDR:8080"
  s3_secret_key                   = "secret-key"
  s3_access_key                   = "access-key"
  ssc                             = { channel = "1/stable" }
  traefik                         = { channel = "latest/stable" }
}
```
`terraform validate`

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
