### PR TITLE
fix: TF submodule refs point to track/2

### DIFF
--- a/terraform/cos-lite/applications.tf
+++ b/terraform/cos-lite/applications.tf
@@ -1,5 +1,5 @@
 module "alertmanager" {
-  source             = "git::https://github.com/canonical/alertmanager-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/alertmanager-k8s-operator//terraform?ref=track/2"
   app_name           = var.alertmanager.app_name
   channel            = var.channel
   config             = var.alertmanager.config
@@ -11,7 +11,7 @@ module "alertmanager" {
 }
 
 module "catalogue" {
-  source             = "git::https://github.com/canonical/catalogue-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/catalogue-k8s-operator//terraform?ref=track/2"
   app_name           = var.catalogue.app_name
   channel            = var.channel
   config             = var.catalogue.config
@@ -23,7 +23,7 @@ module "catalogue" {
 }
 
 module "grafana" {
-  source             = "git::https://github.com/canonical/grafana-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/grafana-k8s-operator//terraform?ref=track/2"
   app_name           = var.grafana.app_name
   channel            = var.channel
   config             = var.grafana.config
@@ -35,7 +35,7 @@ module "grafana" {
 }
 
 module "loki" {
-  source             = "git::https://github.com/canonical/loki-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/loki-k8s-operator//terraform?ref=track/2"
   app_name           = var.loki.app_name
   channel            = var.channel
   config             = var.loki.config
@@ -47,7 +47,7 @@ module "loki" {
 }
 
 module "prometheus" {
-  source             = "git::https://github.com/canonical/prometheus-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/prometheus-k8s-operator//terraform?ref=track/2"
   app_name           = var.prometheus.app_name
   channel            = var.channel
   config             = var.prometheus.config

--- a/terraform/cos/applications.tf
+++ b/terraform/cos/applications.tf
@@ -1,5 +1,5 @@
 module "alertmanager" {
-  source             = "git::https://github.com/canonical/alertmanager-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/alertmanager-k8s-operator//terraform?ref=track/2"
   app_name           = var.alertmanager.app_name
   channel            = var.channel
   config             = var.alertmanager.config
@@ -11,7 +11,7 @@ module "alertmanager" {
 }
 
 module "catalogue" {
-  source             = "git::https://github.com/canonical/catalogue-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/catalogue-k8s-operator//terraform?ref=track/2"
   app_name           = var.catalogue.app_name
   channel            = var.channel
   config             = var.catalogue.config
@@ -23,7 +23,7 @@ module "catalogue" {
 }
 
 module "grafana" {
-  source             = "git::https://github.com/canonical/grafana-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/grafana-k8s-operator//terraform?ref=track/2"
   app_name           = var.grafana.app_name
   channel            = var.channel
   config             = var.grafana.config
@@ -35,7 +35,7 @@ module "grafana" {
 }
 
 module "loki" {
-  source                           = "git::https://github.com/canonical/observability-stack//terraform/loki"
+  source                           = "git::https://github.com/canonical/observability-stack//terraform/loki?ref=track/2"
   anti_affinity                    = var.anti_affinity
   channel                          = var.channel
   model_uuid                       = var.model_uuid
@@ -66,7 +66,7 @@ module "loki" {
 }
 
 module "mimir" {
-  source                           = "git::https://github.com/canonical/observability-stack//terraform/mimir"
+  source                           = "git::https://github.com/canonical/observability-stack//terraform/mimir?ref=track/2"
   anti_affinity                    = var.anti_affinity
   channel                          = var.channel
   model_uuid                       = var.model_uuid
@@ -105,7 +105,7 @@ module "mimir" {
 }
 
 module "opentelemetry_collector" {
-  source             = "git::https://github.com/canonical/opentelemetry-collector-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/opentelemetry-collector-k8s-operator//terraform?ref=track/2"
   app_name           = var.opentelemetry_collector.app_name
   channel            = var.channel
   config             = var.opentelemetry_collector.config
@@ -129,7 +129,7 @@ module "ssc" {
 }
 
 module "tempo" {
-  source                           = "git::https://github.com/canonical/tempo-operators//terraform"
+  source                           = "git::https://github.com/canonical/tempo-operators//terraform?ref=track/2"
   anti_affinity                    = var.anti_affinity
   channel                          = var.channel
   model_uuid                       = var.model_uuid

--- a/terraform/loki/main.tf
+++ b/terraform/loki/main.tf
@@ -38,7 +38,7 @@ resource "juju_application" "s3_integrator" {
 }
 
 module "loki_coordinator" {
-  source             = "git::https://github.com/canonical/loki-coordinator-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/loki-coordinator-k8s-operator//terraform?ref=track/2"
   app_name           = "loki"
   channel            = var.channel
   constraints        = var.anti_affinity ? "arch=amd64 tags=anti-pod.app.kubernetes.io/name=loki,anti-pod.topology-key=kubernetes.io/hostname" : var.coordinator_constraints
@@ -49,7 +49,7 @@ module "loki_coordinator" {
 }
 
 module "loki_backend" {
-  source     = "git::https://github.com/canonical/loki-worker-k8s-operator//terraform"
+  source     = "git::https://github.com/canonical/loki-worker-k8s-operator//terraform?ref=track/2"
   depends_on = [module.loki_coordinator]
 
   app_name    = var.backend_name
@@ -65,7 +65,7 @@ module "loki_backend" {
 }
 
 module "loki_read" {
-  source     = "git::https://github.com/canonical/loki-worker-k8s-operator//terraform"
+  source     = "git::https://github.com/canonical/loki-worker-k8s-operator//terraform?ref=track/2"
   depends_on = [module.loki_coordinator]
 
   app_name    = var.read_name
@@ -81,7 +81,7 @@ module "loki_read" {
 }
 
 module "loki_write" {
-  source     = "git::https://github.com/canonical/loki-worker-k8s-operator//terraform"
+  source     = "git::https://github.com/canonical/loki-worker-k8s-operator//terraform?ref=track/2"
   depends_on = [module.loki_coordinator]
 
   app_name    = var.write_name

--- a/terraform/mimir/main.tf
+++ b/terraform/mimir/main.tf
@@ -38,7 +38,7 @@ resource "juju_application" "s3_integrator" {
 }
 
 module "mimir_coordinator" {
-  source             = "git::https://github.com/canonical/mimir-coordinator-k8s-operator//terraform"
+  source             = "git::https://github.com/canonical/mimir-coordinator-k8s-operator//terraform?ref=track/2"
   app_name           = "mimir"
   channel            = var.channel
   config             = var.coordinator_config
@@ -50,7 +50,7 @@ module "mimir_coordinator" {
 }
 
 module "mimir_backend" {
-  source     = "git::https://github.com/canonical/mimir-worker-k8s-operator//terraform"
+  source     = "git::https://github.com/canonical/mimir-worker-k8s-operator//terraform?ref=track/2"
   depends_on = [module.mimir_coordinator]
 
   app_name    = var.backend_name
@@ -66,7 +66,7 @@ module "mimir_backend" {
 }
 
 module "mimir_read" {
-  source     = "git::https://github.com/canonical/mimir-worker-k8s-operator//terraform"
+  source     = "git::https://github.com/canonical/mimir-worker-k8s-operator//terraform?ref=track/2"
   depends_on = [module.mimir_coordinator]
 
   app_name = var.read_name
@@ -82,7 +82,7 @@ module "mimir_read" {
 }
 
 module "mimir_write" {
-  source     = "git::https://github.com/canonical/mimir-worker-k8s-operator//terraform"
+  source     = "git::https://github.com/canonical/mimir-worker-k8s-operator//terraform?ref=track/2"
   depends_on = [module.mimir_coordinator]
 
   app_name = var.write_name


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We have COS, COS Lite, Mimir, and Loki TF modules on the `track/2` branch which source their modules from main.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add `?ref=track/2` for all submodules on `track/2` branch.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
CI is sufficient for COS Lite. For COS:
```terraform
module "cos" {
  source = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=fix/submodule-refs"
  model_uuid                      = juju_model.cos.uuid
  channel                         = "2/stable"
  internal_tls                    = true
  external_certificates_offer_url = "admin/external-ca.certificates"
  external_ca_cert_offer_url      = "admin/external-ca.send-ca-cert"
  ...
}
```
```console
Apply complete! Resources: 100 added, 0 changed, 0 destroyed.
```
