### PR TITLE
fix: workflow dispatch

### DIFF
--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -2,6 +2,24 @@ name: Test the Terraform product module
 
 on:
   workflow_dispatch:
+    inputs:
+      product:
+        description: 'The name of the Terraform product module to test.'
+        required: true
+        type: choice
+        default: cos
+        options:
+        - cos
+        - cos_lite
+      runner:
+        description: 'The runner label to use for the job.'
+        type: choice
+        default: ubuntu-latest
+        options:
+        - ubuntu-latest
+        - self-hosted-linux-amd64-noble-large
+        - self-hosted-linux-amd64-noble-xlarge
+        - self-hosted-linux-amd64-noble-2xlarge
   workflow_call:
     inputs:
       product:


### PR DESCRIPTION
- [ ] backport into `track/2`

## Issue
<!-- What issue is this PR trying to solve? -->
Workflow dispatch does not work because it is missing inputs

## Solution
<!-- A summary of the solution addressing the above issue -->
Fix the workflow dispatch

### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 
