### PR TITLE
docs: point to correct file for cos-lite variables.tf

### DIFF
--- a/docs/tutorial/installation/cos-lite-microk8s-sandbox.md
+++ b/docs/tutorial/installation/cos-lite-microk8s-sandbox.md
@@ -182,7 +182,7 @@ Create a `cos-lite-microk8s-sandbox.tf` file with the following Terraform module
 
 <!-- if Field wants, allow setting `anti_affinity` by something other than `kubernetes/hostname` -->
 
-**Note**: You can customize further the revisions of each charm and other aspects of COS Lite: have a look at the [`variables.tf`](../../../terraform/cos/variables.tf) file of the COS Lite Terraform module for the complete documentation.
+**Note**: You can customize further the revisions of each charm and other aspects of COS Lite: have a look at the [`variables.tf`](../../../terraform/cos-lite/variables.tf) file of the COS Lite Terraform module for the complete documentation.
 
 <!-- Once we allow enabling internal TLS and external TLS separately, add the explanation to this tutorial -->
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #204.

## Solution
<!-- A summary of the solution addressing the above issue -->
Points to the correct link file which is: https://github.com/canonical/observability-stack/blob/main/terraform/cos-lite/variables.tf.
This change will require a backport to track 2.
### Checklist
- [ x ] I have added or updated relevant documentation.
- [ x ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ x ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
