### PR TITLE
fix: Tiering HowTo doc with OTLP endpoints

### DIFF
--- a/docs/how-to/tiered-otelcols.md
+++ b/docs/how-to/tiered-otelcols.md
@@ -16,8 +16,8 @@ flowchart TB
 
 flog[flog] --> fan-out
 fan-out["opentelemetry-collector<br>(redact & batch)"]
-fan-out --> warn
-fan-out --> info
+fan-out --send-otlp--> warn
+fan-out --send-otlp--> info
 warn["opentelemetry-collector<br>(cold filter)"] --> loki-cold
 info["opentelemetry-collector<br>(hot filter)"] --> loki-hot
 loki-hot["loki<br>(hot storage)"]
@@ -55,10 +55,10 @@ Another imaginable scenario is classifying log streams prior to ingestion into a
 flowchart TB
 
 flog-dev["flog<br>(dev)"] --> dev
-dev["opentelemetry-collector<br>(dev attributes)"] --> fan-in
+dev["opentelemetry-collector<br>(dev attributes)"] --send-otlp--> fan-in
 
 flog-prod["flog<br>(prod)"] --> prod
-prod["opentelemetry-collector<br>(prod attributes)"] --> fan-in
+prod["opentelemetry-collector<br>(prod attributes)"] --send-otlp--> fan-in
 
 fan-in["opentelemetry-collector<br>(redact & batch)"] --> loki[loki]
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Resolves partially https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/120

## Solution
<!-- A summary of the solution addressing the above issue -->
Although this is a flaw in the Loki exporter and the lack of a tiering feature prior to OTLP, the tiering doc needed to be updated to be explicit that `send-otlp` is to be used when tiering otelcols.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 