### PR TITLE
Update release policy document for clarity

### DIFF
--- a/docs/reference/release-policy.md
+++ b/docs/reference/release-policy.md
@@ -7,7 +7,7 @@ We release every six months, same as Ubuntu, and our LTS releases coincide with 
 ## Short-term releases
 Short-term releases are supported for nine months by providing security patches and critical bug fixes.
 
-| Track | Release date | End of life | Ubuntu base                          | Min. Juju version | Brief summary                                                                                             |
+| Track | Release date | End of standard security maintenance | Ubuntu base                          | Min. Juju version | Brief summary                                                                                             |
 | ----- | ------------ | ----------- | ------------------------------------ | ----------------- | --------------------------------------------------------------------------------------------------------- |
 | `2`   | 2025-11      | 2026-07     | 24.04 (rocks), 22.04+ (subordinates) | 3.6               | Mimir 2.x, Prometheus 2.x, Loki 2.x (COS Lite), Loki 3.0 (COS), Grafana 12.x, opentelemetry-collector 0.x |
 | `1`   | 2025-05      | 2026-02     | 24.04 (rocks)                        | 3.1               | Mimir 2.x, Prometheus 2.x, Loki 2.x (COS Lite), Loki 3.0 (COS), Grafana 9.x, Grafana Agent 0.40.4         |
@@ -15,9 +15,9 @@ Short-term releases are supported for nine months by providing security patches 
 
 ## Long-term support
 
-| Track   | Release date        | End of life         | Ubuntu base                          | Min. Juju version | Brief summary |
+| Track   | Release date        | End of standard security maintenance | Ubuntu base                          | Min. Juju version | Brief summary |
 | ------- | ------------------- | ------------------- | ------------------------------------ | ----------------- | ------------- |
-| `3-lts` | 2026-04 (predicted) | 2038-04 (predicted) | 26.04 (rocks), 22.04+ (subordinates) |                   |               |
+| `3-lts` | 2026-04 (predicted) | 2031-04 (predicted) | 26.04 (rocks), 22.04+ (subordinates) |                   |               |
 
 
 ## Charmhub tracks and git branches


### PR DESCRIPTION
This PR updates the language and period for standard security maintenance.
This is a track/2 tandem to https://github.com/canonical/observability-stack/pull/231