### PR TITLE
docs: Add note on ubuntu pro support

### DIFF
--- a/docs/reference/release-policy.md
+++ b/docs/reference/release-policy.md
@@ -5,6 +5,7 @@ Our release policy includes two kinds of releases, short-term releases and long-
 We release every six months, same as Ubuntu, and our LTS releases coincide with [Ubuntu's LTS release cadence](https://ubuntu.com/about/release-cycle).
 
 ## Short-term releases
+
 Short-term releases are supported for nine months by providing security patches and critical bug fixes.
 
 | Track | Release date | End of standard security maintenance | Ubuntu base                          | Min. Juju version | Brief summary                                                                                             |
@@ -21,5 +22,10 @@ Short-term releases are supported for nine months by providing security patches 
 
 
 ## Charmhub tracks and git branches
+
 We create the Charmhub track at beginning of a cycle, and a git branch at end of cycle.
 For example, during June-September 2025, we had track `2` on Charmhub, but only `track/1` and `main` branches on github.
+
+## Support for Ubuntu Pro customers
+
+If you have an Ubuntu Pro Support subscription, both track 1 and track 2 will receive ticket break/bug fix support until 6 months after the release of track 3.


### PR DESCRIPTION
## Issue
Support reached out saying some customers are unsure about how long tracks 1 and 2 are supported. The information (support window) here came from Support

**Question: Should this also go in `latest`?** If this is always true - that a track is Pro Support subscriptions get support for 6 months after the next track is released - I'd rather word it more generally there.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 
