### PR TITLE
feat(doc): enable direct link to editing pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,7 +165,7 @@ html_extra_path = []
 # - https://git.launchpad.net/example
 #
 html_theme_options = {
-  'source_edit_link': 'https://github.com/canonical/observability-stack',
+    'source_edit_link': 'https://github.com/canonical/observability-stack',
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,9 +164,9 @@ html_extra_path = []
 # - https://launchpad.net/example
 # - https://git.launchpad.net/example
 #
-# html_theme_options = {
-# 'source_edit_link': 'https://github.com/canonical/sphinx-docs-starter-pack',
-# }
+html_theme_options = {
+  'source_edit_link': 'https://github.com/canonical/observability-stack',
+}
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
 #


### PR DESCRIPTION
Currently we have a "Give feedback" button, but it opens an issue.
We would like to be taken directly to the "edit file" link on github.

This PR adds the pencil button to doc pages or RTD.
<img width="226" height="79" alt="image" src="https://github.com/user-attachments/assets/cbbcdf9b-b9af-4eb6-8d1d-522fa998bcda" />

h/t @YanisaHS 