### PR TITLE
Doc: Update cos-lite terraform with custom storage

### DIFF
--- a/docs/how-to/configure-and-tune/customize-storage-options.md
+++ b/docs/how-to/configure-and-tune/customize-storage-options.md
@@ -2,41 +2,43 @@
 
 ## Configure custom storage class
 
-You may want to use custom storage classes like ceph or cinder backed PVCs for your containers. List the available storage classes if needed:
+You may want to use custom storage classes like ceph or cinder backed PVCs for your containers. List the available storage classes:
+
+```bash
+kubectl get sc
 ```
-$ kubectl get sc
-```
-For example, I want all the pods to be deployed with a PVC that is provisioned by `ceph-xfs` storage class:
 ```
 NAME                  PROVISIONER              RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE    
 ceph-ext4             rbd.csi.ceph.com         Delete          Immediate              true                   2d22h  
 ceph-xfs              rbd.csi.ceph.com         Delete          Immediate              true                   2d22h  
 csi-rawfile-default   rawfile.csi.openebs.io   Delete          WaitForFirstConsumer   false                  3d1h   
 ```
-Modify the `juju_model` resource in the base file with a `workload-storage` config:
-```
+
+For example, to have all the pods deployed with a PVC that is provisioned by `ceph-xfs` storage class, modify the `juju_model`
+resource in the base file with a `workload-storage` config:
+
+```diff
 resource "juju_model" "cos" {                             
   name   = "cos"                                          
   config = { logging-config = "<root>=WARNING; unit=DEBUG"
   
-  # Add this line  
-  workload-storage = "ceph-xfs"      
++ workload-storage = "ceph-xfs"      
   }                                
 }
 ```
 
 
+## Configure custom storage sizes
 
-## Configure custom storage sizes 
-
-Additionally, it is recommended to modify the size of your PVC, specially since components like loki and prometheus are storage intensive. 
+Since COS components are storage intensive, it is recommended to modify the size of your PVC.
 
 ```{important}
 If you don't specify a size, a PVC will be created with a default size of 1G backed by the storage class you configured. 
 ```
 
-Add a `storage_directive` for each storage container under the `cos-lite` module in the same base terraform file:
-```
+Add a `storage_directive` for each storage container in your terraform file. For COS Lite it may look like this:
+
+```diff
 module "cos-lite" {                                                                                    
   source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2" 
   model_uuid = juju_model.cos.uuid
@@ -44,46 +46,28 @@ module "cos-lite" {
   ssc        = { channel = "1/stable" }
   traefik    = { channel = "latest/stable" }
 
-  # Adding storage for Prometheus
-  prometheus = {
-    storage_directives = { "database" = "200G" }
-  }      
++ # Adding storage for Prometheus
++ prometheus = {
++   storage_directives = { "database" = "200G" }
++ }      
 
-  # Adding storage for Loki
-  loki = {
-    storage_directives = { "loki-chunks" = "400G" }
-  }     
++ # Adding storage for Loki
++ loki = {
++   storage_directives = { "loki-chunks" = "400G" }
++ }     
 
-  # Adding storage for Alertmanager (Note the key is usually "data")
-  alertmanager = {
-    storage_directives = { "data" = "100G" }
-  }
++ # Adding storage for Alertmanager (Note the key is usually "data")
++ alertmanager = {
++   storage_directives = { "data" = "100G" }
++ }
 }
 ```
+
 This shows 3 examples setting sizes for prometheus, loki and alertmanager using the syntax
 `{storage_directives = {<storage_name> = "<size>"}}`
 
-To know the key names for other components, refer to the table below:
+You can find the names of relevant storage volumes in the [storage reference](/reference/storage).
 
-|Component|Storage name|
-|---|---|
-|Prometheus|database|
-|loki|loki-chunks|
-|loki|active-index-directory|
-|alertmanager|data|
-|grafana|database|
-|traefik|configurations|
+## External links
 
-It is good to know that `storage_directives` can also take `pool` and `count` values, providing additional flexibility when configuring storage classes. Here are a couple of more examples:
-```
-storage_directives = {
-    "pgdata" = "4G" # 4 gigabytes of storage for pgdata using the model's default storage pool
-    # or
-    "pgdata" = "2,4G" # 2 instances of 4 gigabytes of storage for pgdata using the model's default storage pool
-    # or
-    "pgdata" = "ebs,2,4G" # 2 instances of 4 gigabytes of storage for pgdata on the ebs storage pool
-  }
-```
-## Reference
-
-[Example of using `storage_directives`](https://documentation.ubuntu.com/terraform-provider-juju/latest/reference/terraform-provider/resources/application/#juju-application-resource)
+- [Example of using `storage_directives`](https://documentation.ubuntu.com/terraform-provider-juju/latest/reference/terraform-provider/resources/application/#juju-application-resource)

--- a/docs/how-to/configure-and-tune/customize-storage-options.md
+++ b/docs/how-to/configure-and-tune/customize-storage-options.md
@@ -1,0 +1,89 @@
+# Customize storage options
+
+## Configure custom storage class
+
+You may want to use custom storage classes like ceph or cinder backed PVCs for your containers. List the available storage classes if needed:
+```
+$ kubectl get sc
+```
+For example, I want all the pods to be deployed with a PVC that is provisioned by `ceph-xfs` storage class:
+```
+NAME                  PROVISIONER              RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE    
+ceph-ext4             rbd.csi.ceph.com         Delete          Immediate              true                   2d22h  
+ceph-xfs              rbd.csi.ceph.com         Delete          Immediate              true                   2d22h  
+csi-rawfile-default   rawfile.csi.openebs.io   Delete          WaitForFirstConsumer   false                  3d1h   
+```
+Modify the `juju_model` resource in the base file with a `workload-storage` config:
+```
+resource "juju_model" "cos" {                             
+  name   = "cos"                                          
+  config = { logging-config = "<root>=WARNING; unit=DEBUG"
+  
+  # Add this line  
+  workload-storage = "ceph-xfs"      
+  }                                
+}
+```
+
+
+
+## Configure custom storage sizes 
+
+Additionally, it is recommended to modify the size of your PVC, specially since components like loki and prometheus are storage intensive. 
+
+```{important}
+If you don't specify a size, a PVC will be created with a default size of 1G backed by the storage class you configured. 
+```
+
+Add a `storage_directive` for each storage container under the `cos-lite` module in the same base terraform file:
+```
+module "cos-lite" {                                                                                    
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2" 
+  model_uuid = juju_model.cos.uuid
+  channel    = "2/stable"
+  ssc        = { channel = "1/stable" }
+  traefik    = { channel = "latest/stable" }
+
+  # Adding storage for Prometheus
+  prometheus = {
+    storage_directives = { "database" = "200G" }
+  }      
+
+  # Adding storage for Loki
+  loki = {
+    storage_directives = { "loki-chunks" = "400G" }
+  }     
+
+  # Adding storage for Alertmanager (Note the key is usually "data")
+  alertmanager = {
+    storage_directives = { "data" = "100G" }
+  }
+}
+```
+This shows 3 examples setting sizes for prometheus, loki and alertmanager using the syntax
+`{storage_directives = {<storage_name> = "<size>"}}`
+
+To know the key names for other components, refer to the table below:
+
+|Component|Storage name|
+|---|---|
+|Prometheus|database|
+|loki|loki-chunks|
+|loki|active-index-directory|
+|alertmanager|data|
+|grafana|database|
+|traefik|configurations|
+
+It is good to know that `storage_directives` can also take `pool` and `count` values, providing additional flexibility when configuring storage classes. Here are a couple of more examples:
+```
+storage_directives = {
+    "pgdata" = "4G" # 4 gigabytes of storage for pgdata using the model's default storage pool
+    # or
+    "pgdata" = "2,4G" # 2 instances of 4 gigabytes of storage for pgdata using the model's default storage pool
+    # or
+    "pgdata" = "ebs,2,4G" # 2 instances of 4 gigabytes of storage for pgdata on the ebs storage pool
+  }
+```
+## Reference
+
+[Example of using `storage_directives`](https://documentation.ubuntu.com/terraform-provider-juju/latest/reference/terraform-provider/resources/application/#juju-application-resource)

--- a/docs/how-to/configure-and-tune/customize-storage-options.md
+++ b/docs/how-to/configure-and-tune/customize-storage-options.md
@@ -1,8 +1,8 @@
-# Customize storage options
+# How to customize storage options
 
 ## Configure custom storage class
 
-You may want to use custom storage classes like ceph or cinder backed PVCs for your containers. List the available storage classes:
+You may want to use custom storage classes like Ceph or Cinder-backed PVCs for your containers. List the available storage classes:
 
 ```bash
 kubectl get sc
@@ -63,7 +63,7 @@ module "cos-lite" {
 }
 ```
 
-This shows 3 examples setting sizes for prometheus, loki and alertmanager using the syntax
+This shows 3 examples setting sizes for Prometheus, Loki and Alertmanager using the syntax
 `{storage_directives = {<storage_name> = "<size>"}}`
 
 You can find the names of relevant storage volumes in the [storage reference](/reference/storage).

--- a/docs/how-to/configure-and-tune/customize-storage-options.md
+++ b/docs/how-to/configure-and-tune/customize-storage-options.md
@@ -1,4 +1,12 @@
+---
+myst:
+ html_meta:
+   description: "Customize storage options for Canonical Observability Stack charms, using the Juju Terraform provider."
+---
+
 # How to customize storage options
+
+This guide describes how to configure storage classes and volume sizes for COS components, using the Juju Terraform provider.
 
 ## Configure custom storage class
 

--- a/docs/how-to/configure-and-tune/index.md
+++ b/docs/how-to/configure-and-tune/index.md
@@ -38,4 +38,6 @@ storage.
 :maxdepth: 1
 
 Redact sensitive data <redact-sensitive-data>
+customize-storage-options
+reference-k8s-cloud-for-cos
 ```

--- a/docs/how-to/configure-and-tune/reference-k8s-cloud-for-cos.md
+++ b/docs/how-to/configure-and-tune/reference-k8s-cloud-for-cos.md
@@ -1,8 +1,8 @@
 
-# Reference a specific cloud to deploy COS
+# How to reference a specific cloud to deploy COS
 
 In situations where multiple clouds are registered in the controller, you must specify where to deploy the model,
-Reference your cloud and credentials in the base terraform plan. First, see what cloud and credentials are stored in the authenticated controller.
+Reference your cloud and credentials in the base Terraform plan. First, see what cloud and credentials are stored in the authenticated controller.
 For example:
 
 ```bash
@@ -23,7 +23,7 @@ Cloud      Credentials
 k8s-cloud  k8s-cloud     
 ```
 
-Add a `cloud` block and a `credential` reference in the base terraform file within the `juju_model` resource:
+Add a `cloud` block and a `credential` reference in the base Terraform file within the `juju_model` resource:
 
 ```diff
 resource "juju_model" "cos" {

--- a/docs/how-to/configure-and-tune/reference-k8s-cloud-for-cos.md
+++ b/docs/how-to/configure-and-tune/reference-k8s-cloud-for-cos.md
@@ -1,0 +1,36 @@
+
+# Reference a specific cloud to deploy COS
+
+In situations where multiple clouds are registered in the controller, you must specify where to deploy the model,
+Reference your cloud and credentials in the base terraform plan. First, see what cloud and credentials are stored in the authenticated controller using:
+```
+$ juju clouds
+$ juju credentials
+```
+For example:
+```
+Clouds available on the controller:  
+Cloud      Regions  Default     Type 
+k8s-cloud  1        default     k8s  
+
+Controller Credentials:  
+Cloud      Credentials   
+k8s-cloud  k8s-cloud     
+```
+Add a `cloud` block and a `credential` reference in the base terraform file within the `juju_model` resource:
+```
+resource "juju_model" "cos" {
+  name   = "cos"
+  config = { logging-config = "<root>=WARNING; unit=DEBUG" }
+  
+  # Add this block
+  cloud {                                                 
+    name   = "k8s-cloud"                                  
+    region = "default"                                    
+  }                                                       
+  credential = "k8s-cloud"     
+}   
+```
+Save and exit. 
+
+To read more about managing clouds, refer to the [Manage clouds](https://documentation.ubuntu.com/terraform-provider-juju/latest/howto/manage-clouds/#add-a-kubernetes-cloud) section of Terraform Provider for Juju

--- a/docs/how-to/configure-and-tune/reference-k8s-cloud-for-cos.md
+++ b/docs/how-to/configure-and-tune/reference-k8s-cloud-for-cos.md
@@ -2,35 +2,40 @@
 # Reference a specific cloud to deploy COS
 
 In situations where multiple clouds are registered in the controller, you must specify where to deploy the model,
-Reference your cloud and credentials in the base terraform plan. First, see what cloud and credentials are stored in the authenticated controller using:
-```
-$ juju clouds
-$ juju credentials
-```
+Reference your cloud and credentials in the base terraform plan. First, see what cloud and credentials are stored in the authenticated controller.
 For example:
+
+```bash
+juju clouds
+```
 ```
 Clouds available on the controller:  
 Cloud      Regions  Default     Type 
 k8s-cloud  1        default     k8s  
+```
 
+```bash
+juju credentials
+```
+```
 Controller Credentials:  
 Cloud      Credentials   
 k8s-cloud  k8s-cloud     
 ```
+
 Add a `cloud` block and a `credential` reference in the base terraform file within the `juju_model` resource:
-```
+
+```diff
 resource "juju_model" "cos" {
   name   = "cos"
   config = { logging-config = "<root>=WARNING; unit=DEBUG" }
   
-  # Add this block
-  cloud {                                                 
-    name   = "k8s-cloud"                                  
-    region = "default"                                    
-  }                                                       
-  credential = "k8s-cloud"     
++ cloud {                                                 
++   name   = "k8s-cloud"                                  
++   region = "default"                                    
++ }                                                       
++ credential = "k8s-cloud"     
 }   
 ```
-Save and exit. 
 
-To read more about managing clouds, refer to the [Manage clouds](https://documentation.ubuntu.com/terraform-provider-juju/latest/howto/manage-clouds/#add-a-kubernetes-cloud) section of Terraform Provider for Juju
+To read more about managing clouds, refer to the [Manage clouds](https://documentation.ubuntu.com/terraform-provider-juju/latest/howto/manage-clouds/#add-a-kubernetes-cloud) section of Terraform Provider for Juju.

--- a/docs/how-to/configure-and-tune/reference-k8s-cloud-for-cos.md
+++ b/docs/how-to/configure-and-tune/reference-k8s-cloud-for-cos.md
@@ -1,3 +1,8 @@
+---
+myst:
+ html_meta:
+   description: "Specify which Juju cloud and credential to use for Canonical Observability Stack deployment."
+---
 
 # How to reference a specific cloud to deploy COS
 

--- a/docs/tutorial/cos-lite-microk8s-sandbox.md
+++ b/docs/tutorial/cos-lite-microk8s-sandbox.md
@@ -242,10 +242,10 @@ Modify the `juju_model` resource in the same file with a `workload-storage` conf
 ```
 resource "juju_model" "cos" {                             
   name   = "cos"                                          
-  config = { logging-config = "<root>=WARNING; unit=DEBUG"
-  
-  # Add this line  
-  workload-storage = "ceph-xfs"      
+  config = {
+     logging-config = "<root>=WARNING; unit=DEBUG"
+     # Add this line  
+     workload-storage = "ceph-xfs"      
   }  
                                                      
   cloud {                                                 

--- a/docs/tutorial/cos-lite-microk8s-sandbox.md
+++ b/docs/tutorial/cos-lite-microk8s-sandbox.md
@@ -195,124 +195,13 @@ Create a `cos-lite-microk8s-sandbox.tf` file with the following Terraform module
 
 It is usually a good idea to create a dedicated model for COS Lite. This module creates one named `cos`, which you can override.
 
-### Add cloud credentials
-Reference your cloud and credentials in the base terraform plan. First, see what cloud and credentials are stored using:
-```
-$ juju clouds
-$ juju credentials
-```
-For example:
-```
-Clouds available on the controller:  
-Cloud      Regions  Default     Type 
-k8s-cloud  1        default     k8s  
+If there are multiple clouds registered in the controller or a default cloud is not setup, an explicit reference of the cloud in the base terraform file needs to exist. Look at [how to reference a K8s cloud](../how-to/configure-and-tune/reference-k8s-cloud-for-cos.md) section.
 
-Controller Credentials:  
-Cloud      Credentials   
-k8s-cloud  k8s-cloud     
-```
-Add a `cloud` block and a `credential` reference in the main `cos-lite-microk8s-sandbox.tf` file within the `juju_model` resource:
-```
-resource "juju_model" "cos" {
-  name   = "cos"
-  config = { logging-config = "<root>=WARNING; unit=DEBUG" }
-  
-  # Add this block
-  cloud {                                                 
-    name   = "k8s-cloud"                                  
-    region = "default"                                    
-  }                                                       
-  credential = "k8s-cloud"     
-}   
-```
-### Configure custom storage class
 
-You may want to use custom storage classes like ceph or cinder backed PVCs for your containers. List the available storage classes if needed:
-```
-$ kubectl get sc
-```
-For example, I want all the pods to be deployed with a PVC that is provisioned by `ceph-xfs` storage class:
-```
-NAME                  PROVISIONER              RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE    
-ceph-ext4             rbd.csi.ceph.com         Delete          Immediate              true                   2d22h  
-ceph-xfs              rbd.csi.ceph.com         Delete          Immediate              true                   2d22h  
-csi-rawfile-default   rawfile.csi.openebs.io   Delete          WaitForFirstConsumer   false                  3d1h   
-```
-Modify the `juju_model` resource in the same file with a `workload-storage` config:
-```
-resource "juju_model" "cos" {                             
-  name   = "cos"                                          
-  config = {
-     logging-config = "<root>=WARNING; unit=DEBUG"
-     # Add this line  
-     workload-storage = "ceph-xfs"      
-  }  
-                                                     
-  cloud {                                                 
-    name   = "k8s-cloud"                                  
-    region = "default"                                    
-  }                                                       
-  credential = "k8s-cloud"                                
-}
-```
+By default, COS uses local files on k8s node to store data. 
+To use a custom storage class for container's persistent volume during deployment, refer to guide: [how to configure custom storage options](../how-to/configure-and-tune/customize-storage-options.md)
 
-### Configure custom storage sizes 
 
-Additionally, it is recommended to modify the size of your PVC, especially since components like Loki and Prometheus are storage intensive. 
-
-```{important}
-If you don't specify a size, a PVC will be created with a default size of 1G backed by the storage class you configured. 
-```
-
-Add `storage_directives` for each storage container under the `cos-lite` module in the same base terraform file:
-```
-module "cos-lite" {                                                                                    
-  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2" 
-  model_uuid = juju_model.cos.uuid
-  channel    = "2/stable"
-  ssc        = { channel = "1/stable" }
-  traefik    = { channel = "latest/stable" }
-
-  # Adding storage for Prometheus
-  prometheus = {
-    storage_directives = { "database" = "200G" }
-  }      
-
-  # Adding storage for Loki
-  loki = {
-    storage_directives = { "loki-chunks" = "400G" }
-  }     
-
-  # Adding storage for Alertmanager (Note the key is usually "data")
-  alertmanager = {
-    storage_directives = { "data" = "100G" }
-  }
-}
-```
-This shows 3 examples setting sizes for prometheus, loki and alertmanager using the syntax
-`{storage_directives = {<storage_name> = "<size>"}}`
-
-To know the key names for other components, refer to the table below:
-
-|Component|Storage name|
-|---|---|
-|Prometheus|database|
-|loki|loki-chunks|
-|loki|active-index-directory|
-|alertmanager|data|
-|grafana|database|
-|traefik|configurations|
-
-It is good to know that storage directives can also take `pool` and `count` values, providing additional flexibility when configuring storage classes. Here are a couple of more examples:
-```
-storage_directives = {
-    "pgdata" = "4G" # 4 gigabytes of storage for pgdata using the model's default storage pool
-    # or
-    "pgdata" = "2,4G" # 2 instances of 4 gigabytes of storage for pgdata using the model's default storage pool
-    # or
-    "pgdata" = "ebs,2,4G" # 2 instances of 4 gigabytes of storage for pgdata on the ebs storage pool
-  }
-```
 
 Next, deploy COS Lite in the new model, run:
 

--- a/docs/tutorial/cos-lite-microk8s-sandbox.md
+++ b/docs/tutorial/cos-lite-microk8s-sandbox.md
@@ -264,7 +264,7 @@ Additionally, it is recommended to modify the size of your PVC, especially since
 If you don't specify a size, a PVC will be created with a default size of 1G backed by the storage class you configured. 
 ```
 
-Add a `storage_directive` for each storage container under the `cos-lite` module in the same base terraform file:
+Add `storage_directives` for each storage container under the `cos-lite` module in the same base terraform file:
 ```
 module "cos-lite" {                                                                                    
   source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2" 

--- a/docs/tutorial/cos-lite-microk8s-sandbox.md
+++ b/docs/tutorial/cos-lite-microk8s-sandbox.md
@@ -195,6 +195,125 @@ Create a `cos-lite-microk8s-sandbox.tf` file with the following Terraform module
 
 It is usually a good idea to create a dedicated model for COS Lite. This module creates one named `cos`, which you can override.
 
+### Add cloud credentials
+Reference your cloud and credentials in the base terraform plan. First, see what cloud and credentials are stored using:
+```
+$ juju clouds
+$ juju credentials
+```
+For example:
+```
+Clouds available on the controller:  
+Cloud      Regions  Default     Type 
+k8s-cloud  1        default     k8s  
+
+Controller Credentials:  
+Cloud      Credentials   
+k8s-cloud  k8s-cloud     
+```
+Add a `cloud` block and a `credential` reference in the main `cos-lite-microk8s-sandbox.tf` file within the `juju_model` resource:
+```
+resource "juju_model" "cos" {
+  name   = "cos"
+  config = { logging-config = "<root>=WARNING; unit=DEBUG" }
+  
+  # Add this block
+  cloud {                                                 
+    name   = "k8s-cloud"                                  
+    region = "default"                                    
+  }                                                       
+  credential = "k8s-cloud"     
+}   
+```
+### Configure custom storage class
+
+You may want to use custom storage classes like ceph or cinder backed PVCs for your containers. List the available storage classes if needed:
+```
+$ kubectl get sc
+```
+For example, I want all the pods to be deployed with a PVC that is provisioned by `ceph-xfs` storage class:
+```
+NAME                  PROVISIONER              RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE    
+ceph-ext4             rbd.csi.ceph.com         Delete          Immediate              true                   2d22h  
+ceph-xfs              rbd.csi.ceph.com         Delete          Immediate              true                   2d22h  
+csi-rawfile-default   rawfile.csi.openebs.io   Delete          WaitForFirstConsumer   false                  3d1h   
+```
+Modify the `juju_model` resource in the same file with a `workload-storage` config:
+```
+resource "juju_model" "cos" {                             
+  name   = "cos"                                          
+  config = { logging-config = "<root>=WARNING; unit=DEBUG"
+  
+  # Add this line  
+  workload-storage = "ceph-xfs"      
+  }  
+                                                     
+  cloud {                                                 
+    name   = "k8s-cloud"                                  
+    region = "default"                                    
+  }                                                       
+  credential = "k8s-cloud"                                
+}
+```
+
+### Configure custom storage sizes 
+
+Additionally, it is recommended to modify the size of your PVC, specially since components like loki and prometheus are storage intensive. 
+
+```{important}
+If you don't specify a size, a PVC will be created with a default size of 1G backed by the storage class you configured. 
+```
+
+Add a `storage_directive` for each storage container under the `cos-lite` module in the same base terraform file:
+```
+module "cos-lite" {                                                                                    
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2" 
+  model_uuid = juju_model.cos.uuid
+  channel    = "2/stable"
+  ssc        = { channel = "1/stable" }
+  traefik    = { channel = "latest/stable" }
+
+  # Adding storage for Prometheus
+  prometheus = {
+    storage_directives = { "database" = "200G" }
+  }      
+
+  # Adding storage for Loki
+  loki = {
+    storage_directives = { "loki-chunks" = "400G" }
+  }     
+
+  # Adding storage for Alertmanager (Note the key is usually "data")
+  alertmanager = {
+    storage_directives = { "data" = "100G" }
+  }
+}
+```
+This shows 3 examples setting sizes for prometheus, loki and alertmanager using the syntax
+`{storage_directives = {<storage_name> = "<size>"}}`
+
+To know the key names for other components, refer to the table below:
+
+|Component|Storage name|
+|---|---|
+|Prometheus|database|
+|loki|loki-chunks|
+|loki|active-index-directory|
+|alertmanager|data|
+|grafana|database|
+|traefik|configurations|
+
+It is good to know that storage directives can also take `pool` and `count` values, providing additional flexibility when configuring storage classes. Here are a couple of more examples:
+```
+storage_directives = {
+    "pgdata" = "4G" # 4 gigabytes of storage for pgdata using the model's default storage pool
+    # or
+    "pgdata" = "2,4G" # 2 instances of 4 gigabytes of storage for pgdata using the model's default storage pool
+    # or
+    "pgdata" = "ebs,2,4G" # 2 instances of 4 gigabytes of storage for pgdata on the ebs storage pool
+  }
+```
+
 Next, deploy COS Lite in the new model, run:
 
 ```bash

--- a/docs/tutorial/cos-lite-microk8s-sandbox.md
+++ b/docs/tutorial/cos-lite-microk8s-sandbox.md
@@ -258,7 +258,7 @@ resource "juju_model" "cos" {
 
 ### Configure custom storage sizes 
 
-Additionally, it is recommended to modify the size of your PVC, specially since components like loki and prometheus are storage intensive. 
+Additionally, it is recommended to modify the size of your PVC, especially since components like Loki and Prometheus are storage intensive. 
 
 ```{important}
 If you don't specify a size, a PVC will be created with a default size of 1G backed by the storage class you configured. 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Added more information on customizing storage options when deploying cos-lite using terraform. 

## Solution
<!-- A summary of the solution addressing the above issue -->
The changes were specifying global storage class for the PVCs, adding custom size for those PVCs and a table for quick reference regarding storage name for those `storage_directive`. I also added a section to update cloud credentials to avoid targeting ghost clouds, potentially causing errors mid-deployment.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
I tested these configs locally and verified it in kubernetes. All PVCs reflected the correct configured storage class and sizes that were configured. 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Simply go through the process top to bottom. Once its fully deployed, you can verify using:
```
kubectl get pvc -n cos
```

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
