### PR TITLE
docs: Prefix guides with "how to"

### DIFF
--- a/docs/how-to/configure-and-tune/disable-charmed-rules.md
+++ b/docs/how-to/configure-and-tune/disable-charmed-rules.md
@@ -4,7 +4,7 @@ myst:
    description: "Disable built-in charm alert rules in COS, Customize alerting and selectively silence charmed rules for your environment."
 ---
 
-# Disable built-in charm alert rules
+# How to disable built-in charm alert rules
 
 By default, Prometheus and Loki will be configured to evaluate and post alerts for all the
 [charmed rules](/explanation/alerting/charmed-rules) that they receive over relation data.

--- a/docs/how-to/configure-and-tune/redact-sensitive-data.md
+++ b/docs/how-to/configure-and-tune/redact-sensitive-data.md
@@ -4,7 +4,7 @@ myst:
    description: "Redact sensitive telemetry data in COS using OpenTelemetry Collector to redact logs, traces, and metrics before transmission."
 ---
 
-# Redact sensitive data
+# How to redact sensitive data
 
 ## Introduction
 

--- a/docs/how-to/configure-and-tune/selectively-drop-telemetry-otelcol.md
+++ b/docs/how-to/configure-and-tune/selectively-drop-telemetry-otelcol.md
@@ -4,7 +4,7 @@ myst:
    description: "Selectively drop telemetry using OpenTelemetry Collector in COS. Reduce data volume by filtering metrics before ingestion."
 ---
 
-# Selectively drop telemetry using opentelemetry-collector
+# How to selectively drop telemetry using opentelemetry-collector
 
 Sometimes, from a resource perspective, applications are instrumented with more telemetry than we want to afford. In such cases, we can choose to selectively drop some before they are ingested.
 

--- a/docs/how-to/configure-and-tune/selectively-drop-telemetry-scrape-config.md
+++ b/docs/how-to/configure-and-tune/selectively-drop-telemetry-scrape-config.md
@@ -4,7 +4,7 @@ myst:
    description: "Selectively drop telemetry using Prometheus scrape config. Reduce telemetry resources in COS deployment."
 ---
 
-# Selectively drop telemetry using scrape config
+# How to selectively drop telemetry using scrape config
 
 Sometimes, from a resource perspective, applications are instrumented with more telemetry than we want to afford. In such cases, we can choose to selectively drop some before they are ingested.
 

--- a/docs/how-to/install-and-upgrade/configure-tls-encryption.md
+++ b/docs/how-to/install-and-upgrade/configure-tls-encryption.md
@@ -4,7 +4,7 @@ myst:
    description: "Enable TLS encryption in COS and COS Lite - secure communication between Observability Stack components with HTTPS/TLS configuration."
 ---
 
-# TLS encryption in COS
+# How to configure TLS encryption in COS
 
 Both COS and COS Lite, have 2 sections of the deployment (internal and external) which can implement TLS communication.
 

--- a/docs/how-to/install-and-upgrade/upgrade.md
+++ b/docs/how-to/install-and-upgrade/upgrade.md
@@ -4,7 +4,7 @@ myst:
    description: "Upgrade instructions for Canonical Observability Stack. Migrate from COS Lite 1 to COS 2 safely."
 ---
 
-# Upgrade instructions
+# How to upgrade
 
 ## COS 3
 ### Migrate from COS 2 to COS 3

--- a/docs/how-to/integrate/add-tracing-to-cos-lite.md
+++ b/docs/how-to/integrate/add-tracing-to-cos-lite.md
@@ -4,7 +4,7 @@ myst:
    description: "Add distributed tracing to COS Lite - deploy Tempo Coordinator and Worker for complete trace collection and visualization."
 ---
 
-# Add tracing to COS Lite
+# How to add tracing to COS Lite
 
 If you have an existing COS Lite deployment and you wish to add tracing 
 capabilities to it, you can follow the few steps below.

--- a/docs/how-to/integrate/adding-alert-rules.md
+++ b/docs/how-to/integrate/adding-alert-rules.md
@@ -4,7 +4,7 @@ myst:
     description: "Learn how to provide Prometheus and Loki alert rules from your charm via Juju relations, including required interfaces, rule files, and deployment flow."
 ---
 
-# Adding alert rules
+# How to add alert rules
 
 Support for providing alert rules through the relation is available
 for [loki-k8s](https://charmhub.io/loki-k8s) and [prometheus-k8s](https://charmhub.io/prometheus-k8s), both directly and through 

--- a/docs/how-to/integrate/configure-scrape-jobs.md
+++ b/docs/how-to/integrate/configure-scrape-jobs.md
@@ -4,7 +4,7 @@ myst:
    description: "Configure Prometheus scrape jobs in COS - customize the application you want to scrape and metric collection endpoints and intervals for monitoring."
 ---
 
-# Configure Prometheus scrape jobs
+# How to configure Prometheus scrape jobs
 
 By default, the Prometheus charm allows for minimal configuration of the 
 scrape jobs created when you relate it to a remote charm. Instead, we 

--- a/docs/how-to/integrate/deploy-s3-integrator-and-minio.md
+++ b/docs/how-to/integrate/deploy-s3-integrator-and-minio.md
@@ -4,7 +4,7 @@ myst:
    description: "Deploy Minio and S3 Integrator in COS. Use a script or the command line to configure S3-compatible storage for observability."
 ---
 
-# Deploy Minio and S3 Integrator
+# How to deploy Minio and S3 Integrator
 
 ```{warning}
 The Minio charm is not suitable for production usage. Instead, use [Charmed Ceph](https://ubuntu.com/ceph/docs) and follow [this guide](https://discourse.charmhub.io/t/tempo-ha-docs-how-to-use-ceph-backed-s3-storage-for-ha-charms/15740). 

--- a/docs/how-to/integrate/exposing-a-metrics-endpoint.md
+++ b/docs/how-to/integrate/exposing-a-metrics-endpoint.md
@@ -4,7 +4,7 @@ myst:
    description: "Expose metrics endpoints in COS deployments. Enable your charm to get scraped by Prometheus or Grafana."
 ---
 
-# Exposing a Metrics Endpoint
+# How to expose a metrics endpoint
 
 Integrating with the metrics endpoint interface allows you to, through a minimal 
 amount of code, enable your charm to get scraped by a charm like [prometheus-k8s](https://charmhub.io/prometheus-k8s) or [grafana-agent-k8s](https://charmhub.io/grafana-agent-k8s).

--- a/docs/how-to/integrate/instrument-machine-charms.md
+++ b/docs/how-to/integrate/instrument-machine-charms.md
@@ -4,7 +4,7 @@ myst:
   description: "Instrument machine charms with Canonical Observability Stack on Kubernetes using the Opentelemetry Collector subordinate charm for metrics, logs, and dashboards."
 ---
 
-# Instrument machine charms
+# How to instrument machine charms
 
 This guide shows you how to integrate a charm deployed on a machine substrate with the Canonical Observability Stack running on Kubernetes.
 

--- a/docs/how-to/integrate/integrating-cos-lite-with-uncharmed-applications.md
+++ b/docs/how-to/integrate/integrating-cos-lite-with-uncharmed-applications.md
@@ -4,7 +4,7 @@ myst:
    description: "Integrate COS Lite with uncharmed applications using Opentelemetry Collector. Send metrics and logs from non-charm workloads to the observability stack."
 ---
 
-# Integrating COS Lite with uncharmed applications
+# How to integrate COS Lite with uncharmed applications
 
 The [COS Lite solution](https://github.com/canonical/observability-stack/tree/main/terraform/cos-lite) is designed to be deployed and operated using Juju. However, not all workloads that you may want to monitor will be. The good news is that you can use COS Lite to monitor
 workloads that are not charmed (aka "not managed by Juju"). The bad news is that it's relatively straightforward to do so. Not bad at all.

--- a/docs/how-to/integrate/tiered-otelcols.md
+++ b/docs/how-to/integrate/tiered-otelcols.md
@@ -4,7 +4,7 @@ myst:
    description: "Tier OpenTelemetry Collector with different pipelines per data stream. Deploy multiple OpenTelemetry Collector charms to support other architectures."
 ---
 
-# Tier OpenTelemetry Collector with different pipelines per data stream
+# How to tier OpenTelemetry Collector with different pipelines per data stream
 
 By design, [charmed OpenTelemetry Collector](https://charmhub.io/opentelemetry-collector-k8s) (otelcol) forwards all receivers to all exporters.
 For this reason, in order to mimic the wide range of [architectures](https://opentelemetry.io/docs/collector/architecture/) that the pipeline config supports,

--- a/docs/how-to/migrate/migrate-grafana-agent-to-otelcol.md
+++ b/docs/how-to/migrate/migrate-grafana-agent-to-otelcol.md
@@ -4,8 +4,10 @@ myst:
    description: "Migrate from Grafana Agent to OpenTelemetry Collector due to Grafana Agent reaching end-of-life."
 ---
 
-# Migrate from Grafana Agent to OpenTelemetry Collector
+# How to migrate from Grafana Agent to OpenTelemetry Collector
+
 > Grafana Agent has reached End-of-Life (EOL) on November 1, 2025.
+
 Grafana Agent is no longer receiving support, security, or bug fixes from the vendor. Since it is part of COS, the charmed operators for Grafana Agent will continue to  receive bug fixes until July 2026. You should plan to migrate from charmed Grafana Agent to charmed Opentelemetry Collector before that date.
 
 These are the steps to follow:

--- a/docs/how-to/migrate/migrate-lma-to-cos-lite.md
+++ b/docs/how-to/migrate/migrate-lma-to-cos-lite.md
@@ -4,7 +4,7 @@ myst:
    description: "Migrate from LMA to Juju-managed COS Lite. Upgrade observability stack and decomission LMA."
 ---
 
-# Migrate from LMA to COS Lite
+# How to migrate from LMA to COS Lite
 
 COS Lite is not a new version of LMA, but a completely new product that draws upon the lessons learned from LMA to create a heavily integrated,
 mainly automated, turn-key observability stack. This means that there is no direct, in-place migration path.

--- a/docs/how-to/validate-and-troubleshoot/validate-cos-deployment.md
+++ b/docs/how-to/validate-and-troubleshoot/validate-cos-deployment.md
@@ -4,7 +4,7 @@ myst:
   description: "Validate a COS deployment by checking Juju model configurations, charm options, data storage, and more."
 ---
 
-# Validate COS deployment
+# How to validate a COS deployment
 
 ## Juju model
 


### PR DESCRIPTION
## Issue
Prefixing all how-to guides with "How to..." (except for the troubleshooting one)

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 