### PR TITLE
fix: link to observability product page in navbar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,7 @@ html_context = {
     # TODO: If there's no such website,
     #       remove the {{ product_page }} link from the page header template
     #       (usually .sphinx/_templates/header.html; also, see README.rst).
-    "product_page": "github.com/canonical/observability",
+    "product_page": "canonical.com/observability",
     # Product tag image; the orange part of your logo, shown in the page header
     #
     # TODO: To add a tag image, uncomment and update as needed.


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Update the product page link that shows up in the navbar.
Before:
<img width="1729" height="141" alt="image" src="https://github.com/user-attachments/assets/1a272ab3-b966-4fac-9221-459c0d65ecc3" />


After:
<img width="1466" height="70" alt="image" src="https://github.com/user-attachments/assets/f5cbf362-5e39-4194-b72a-164093a5faba" />

## Solution
<!-- A summary of the solution addressing the above issue -->

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
