### PR TITLE
docs: split H1 and H2 in upgrade guide

### DIFF
--- a/docs/how-to/install-and-upgrade/upgrade.md
+++ b/docs/how-to/install-and-upgrade/upgrade.md
@@ -1,10 +1,12 @@
 ---
 myst:
  html_meta:
-   description: "Upgrade instructions for Canonical Observability Stack. Migrate from COS Lite 1 to COS 2 safely."
+   description: "Upgrade instructions for Canonical Observability Stack. Migrate from different COS and COS Lite tracks safely."
 ---
 
 # How to upgrade
+
+This guide shows how to upgrade an existing COS deployment to a newer track.
 
 ## COS 3
 ### Migrate from COS 2 to COS 3


### PR DESCRIPTION
## Issue
fixing metadata and adding a line to break apart the H1/H2

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 