### PR TITLE
docs: use sentence case in sidebar doc titles

### DIFF
--- a/docs/explanation/architecture/cos-lite-model-topology.md
+++ b/docs/explanation/architecture/cos-lite-model-topology.md
@@ -4,7 +4,7 @@ myst:
   description: "Understand COS Lite model topology, including data flow, charm relations, workloads that make up COS Lite, and the architectural structure."
 ---
 
-# Model Topology for COS Lite
+# Model topology for COS Lite
 
 COS Lite consists of a number of charms connected by Juju relations.
 

--- a/docs/explanation/architecture/design-goals.md
+++ b/docs/explanation/architecture/design-goals.md
@@ -4,7 +4,7 @@ myst:
   description: "Understand the design goals of COS and COS Lite: Kubernetes-native, Juju-first observability with integrated telemetry, consistent alerting, and smooth deployment experience."
 ---
 
-# Design Goals
+# Design goals
 
 ## Why a new stack?
 

--- a/docs/explanation/architecture/index.md
+++ b/docs/explanation/architecture/index.md
@@ -18,7 +18,7 @@ The guiding principles and goals behind the COS architecture.
 ```{toctree}
 :maxdepth: 1
 
-Design Goals <design-goals>
+Design goals <design-goals>
 ```
 
 ## Topology & models
@@ -28,9 +28,9 @@ How COS organizes charms, relations, and models within the Juju ecosystem.
 ```{toctree}
 :maxdepth: 1
 
-Juju Topology <juju-topology>
-Juju Topology Labels <juju-topology-labels>
-Model Topology for COS Lite <cos-lite-model-topology>
+Juju topology <juju-topology>
+Juju topology labels <juju-topology-labels>
+Model topology for COS Lite <cos-lite-model-topology>
 ```
 
 ## Stack shape & data flow
@@ -40,5 +40,5 @@ The available stack configurations and how telemetry moves through them.
 ```{toctree}
 :maxdepth: 1
 
-Telemetry Flow <telemetry-flow>
+Telemetry flow <telemetry-flow>
 ```

--- a/docs/explanation/architecture/juju-topology-labels.md
+++ b/docs/explanation/architecture/juju-topology-labels.md
@@ -4,7 +4,7 @@ myst:
   description: "Juju topology labels identify models, charms, and units to contextualize metrics, logs, traces, and dashboards in COS Lite."
 ---
 
-# Juju Topology Labels
+# Juju topology labels
 
 Juju topology labels are [telemetry labels](https://discourse.charmhub.io/t/telemetry-labels-in-the-grafana-ecosystem/8873) that are used for identifying the origin of metrics and logs in juju models. In other words, the Juju topology labels are a fingerprint of a unit in some juju model that is emitting telemetry. Especially when you have hundreds, thousands of nodes, it is essential to be able to locate that one unit that has been causing your alerts to go off.
 Therefore, Juju topology labels play a key role in the Canonical observability stack (COS).

--- a/docs/explanation/architecture/juju-topology.md
+++ b/docs/explanation/architecture/juju-topology.md
@@ -4,7 +4,7 @@ myst:
    description: "Learn how Juju topology metadata identifies telemetry from workloads in Canonical Observability Stack."
 ---
 
-# Juju Topology
+# Juju topology
 
 The Juju topology is a set of metadata associated with each piece of telemetry collected by the COS monitoring stack to uniquely identify which workload is the telemetry reporting about.
 

--- a/docs/explanation/architecture/telemetry-flow.md
+++ b/docs/explanation/architecture/telemetry-flow.md
@@ -4,7 +4,7 @@ myst:
    description: "Understand telemetry data flow in COS and COS Lite: how metrics, logs, and traces move through the observability stack."
 ---
 
-# Telemetry Flow
+# Telemetry flow
 
 ## COS Lite
 

--- a/docs/explanation/operations/data-integrity.md
+++ b/docs/explanation/operations/data-integrity.md
@@ -4,7 +4,7 @@ myst:
   description: "Understand data integrity in COS Lite, which is addressed in Ceph. COS and COS Lite charms don't need additional configuration."
 ---
 
-# Data Integrity
+# Data integrity
 
 COS and COS Lite rely on Kubernetes persistent volumes (PVs) for data persistency. COS charms also rely on S3 storage.
 

--- a/docs/explanation/operations/index.md
+++ b/docs/explanation/operations/index.md
@@ -11,5 +11,5 @@ myst:
 ```{toctree}
 :maxdepth: 1
 
-Data Integrity <data-integrity>
+Data integrity <data-integrity>
 ```

--- a/docs/explanation/overview/index.md
+++ b/docs/explanation/overview/index.md
@@ -19,8 +19,8 @@ matters for managing complex infrastructure.
 ```{toctree}
 :maxdepth: 1
 
-What is Observability? <https://canonical.com/observability/what-is-observability>
-Model-Driven Observability <https://ubuntu.com/blog/tag/model-driven-observability>
+What is observability? <https://canonical.com/observability/what-is-observability>
+Model-driven observability <https://ubuntu.com/blog/tag/model-driven-observability>
 ```
 
 ## About COS

--- a/docs/explanation/telemetry/index.md
+++ b/docs/explanation/telemetry/index.md
@@ -24,9 +24,9 @@ How each signal type is collected and consistently labeled across the stack.
 ```{toctree}
 :maxdepth: 1
 
-Logging Architecture <logging-architecture>
-Telemetry Labels <telemetry-labels>
-Telemetry Collection <telemetry-collection>
+Logging architecture <logging-architecture>
+Telemetry labels <telemetry-labels>
+Telemetry collection <telemetry-collection>
 ```
 
 ## Correlation & interoperability
@@ -37,6 +37,6 @@ telemetry for unified insight.
 ```{toctree}
 :maxdepth: 1
 
-OpenTelemetry Protocol (OTLP) Juju Topology Labels <telemetry-otlp-topology-labels>
-Telemetry Correlation <telemetry-correlation>
+OpenTelemetry Protocol (OTLP) Juju topology labels <telemetry-otlp-topology-labels>
+Telemetry correlation <telemetry-correlation>
 ```

--- a/docs/explanation/telemetry/logging-architecture.md
+++ b/docs/explanation/telemetry/logging-architecture.md
@@ -4,7 +4,7 @@ myst:
   description: "Understand COS logging architecture with Grafana Loki, including ingestion patterns, sending logs, and Juju topology label enrichment for logs."
 ---
 
-# Logging Architecture
+# Logging architecture
 
 In COS, Grafana Loki is the storage and querying backend for logs. Loki is optimized for write performance (ingestion speed), at the cost of slower random reads. This means that filtering structured logs by labels is fast, but full-text search is slower.
 

--- a/docs/explanation/telemetry/telemetry-otlp-topology-labels.md
+++ b/docs/explanation/telemetry/telemetry-otlp-topology-labels.md
@@ -1,4 +1,4 @@
-# Opentelemetry Protocol (OTLP) Juju Topology Labels
+# OpenTelemetry Protocol (OTLP) Juju topology labels
 
 This document focuses on telemetry labeling in the OTLP data model that is core to the opentelemetry-collector (K8s or VM) charm pipelines.
 

--- a/docs/reference/cryptographic-documentation.md
+++ b/docs/reference/cryptographic-documentation.md
@@ -4,7 +4,7 @@ myst:
   description: "Review COS Lite cryptographic documentation covering TLS communication, authentication, and other cryptographic technology."
 ---
 
-# Cryptographic Documentation
+# Cryptographic documentation
 
 ## COS Lite
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -20,7 +20,7 @@ requirements.
 ```{toctree}
 :maxdepth: 1
 
-Sizing Guide <system-requirements>
+Sizing guide <system-requirements>
 Storage <storage>
 ```
 
@@ -32,7 +32,7 @@ compatibility.
 ```{toctree}
 :maxdepth: 1
 
-Release Policy <release-policy>
+Release policy <release-policy>
 ```
 
 ## Security
@@ -43,8 +43,8 @@ these pages before planning or hardening a deployment.
 ```{toctree}
 :maxdepth: 1
 
-Security Hardening Guide <security-hardening-guide>
-Cryptographic Documentation <cryptographic-documentation>
+Security hardening guide <security-hardening-guide>
+Cryptographic documentation <cryptographic-documentation>
 ```
 
 ## Integrations & artifacts
@@ -54,7 +54,7 @@ Compatibility and packaging information for charms, snaps, and rocks (OCI images
 ```{toctree}
 :maxdepth: 1
 
-Integration Matrix <integration-matrix>
+Integration matrix <integration-matrix>
 COS components <cos-components>
 ```
 

--- a/docs/reference/lifecycle.md
+++ b/docs/reference/lifecycle.md
@@ -4,7 +4,7 @@ myst:
   description: "Apply COS lifecycle best practices to plan support windows, coordinate upgrades, and maintain long-term operational consistency across environments."
 ---
 
-# Lifecycle Best Practices
+# Lifecycle best practices
 
 ## Support window
 Refer to [Supported tracks](release-policy) to choose the right track for your needs.

--- a/docs/reference/networking.md
+++ b/docs/reference/networking.md
@@ -4,7 +4,7 @@ myst:
   description: "Follow COS networking best practices for load balancing, ingress design, and reliable service exposure in observability deployments."
 ---
 
-# Networking Best Practices
+# Networking best practices
 
 ## Ingress
 

--- a/docs/reference/security-hardening-guide.md
+++ b/docs/reference/security-hardening-guide.md
@@ -4,7 +4,7 @@ myst:
   description: "Secure COS Lite with encryption, Grafana user management, and Juju hardening for production observability deployments."
 ---
 
-# Security Hardening Guide
+# Security hardening guide
 
 This page is an overview of how to configure COS securely.  While COS is designed with security in mind, some steps are required to ensure your COS is deployed and configured to ensure proper security.
 

--- a/docs/reference/topology.md
+++ b/docs/reference/topology.md
@@ -4,7 +4,7 @@ myst:
   description: "Use COS deployment topology best practices to isolate models and design scalable observability deployments for production systems."
 ---
 
-# Deployment Topology Best Practices
+# Deployment topology best practices
 
 ## Deploy in isolation
 COS (or COS Lite) should be deployed in its own Juju model, and preferably on a separate substrate with a dedicated Juju controller.


### PR DESCRIPTION
This pull request standardizes the capitalization of headings and references throughout the documentation to use sentence case instead of title case. This improves consistency and aligns with style guidelines across the docs. No content or technical changes were made.

No technical or behavioral changes were introduced; these are purely editorial improvements for style and readability.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
