### PR TITLE
feat: TF Otelcol grafana-dashboards-provider integration

### DIFF
--- a/terraform/cos/integrations.tf
+++ b/terraform/cos/integrations.tf
@@ -14,6 +14,10 @@ resource "juju_integration" "grafana_dashboards" {
       app_name = module.loki.app_names.loki_coordinator
       endpoint = module.loki.provides.grafana_dashboards_provider
     }
+    otelcol = {
+      app_name = module.opentelemetry_collector.app_name
+      endpoint = module.opentelemetry_collector.provides.grafana_dashboards_provider
+    }
     tempo = {
       app_name = module.tempo.app_names.tempo_coordinator
       endpoint = module.tempo.provides.grafana_dashboard


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/observability-stack/issues/267

## Solution
<!-- A summary of the solution addressing the above issue -->
Add the integration. We add it only to COS because otelcol is not yet featured in COS Lite. 
