### PR TITLE
fix: TF lint tests

### DIFF
--- a/terraform/cos-lite/applications.tf
+++ b/terraform/cos-lite/applications.tf
@@ -1,4 +1,3 @@
-
 module "alertmanager" {
   source             = "git::https://github.com/canonical/alertmanager-k8s-operator//terraform?ref=track/2"
   app_name           = var.alertmanager.app_name

--- a/terraform/cos-lite/applications.tf
+++ b/terraform/cos-lite/applications.tf
@@ -1,3 +1,4 @@
+
 module "alertmanager" {
   source             = "git::https://github.com/canonical/alertmanager-k8s-operator//terraform?ref=track/2"
   app_name           = var.alertmanager.app_name

--- a/terraform/cos/variables.tf
+++ b/terraform/cos/variables.tf
@@ -58,8 +58,8 @@ variable "cloud" {
   type        = string
   default     = "self-managed"
   validation {
-    condition     = contains(local.clouds, var.cloud) 
-    error_message = "Allowed values are: ${join(", ", local.clouds)}."
+    condition     = contains(["aws", "self-managed"], var.cloud)
+    error_message = "Allowed values are: aws, self-managed."
   }
 }
 

--- a/terraform/cos/variables.tf
+++ b/terraform/cos/variables.tf
@@ -58,7 +58,7 @@ variable "cloud" {
   type        = string
   default     = "self-managed"
   validation {
-    condition     = contains(local.clouds, var.cloud)
+    condition     = contains(local.clouds, var.cloud) 
     error_message = "Allowed values are: ${join(", ", local.clouds)}."
   }
 }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
```shell
│ Error: Reference to uninitialized local value
│ 
│   on variables.tf line 61, in variable "cloud":
│   61:     condition     = contains(local.clouds, var.cloud) 
│ 
│ The local value local.clouds was not processed by the most recent
│ operation, this likely means the previous operation either failed or was
│ incomplete due to targeting.
╵
╷
│ Error: Reference to uninitialized local value
│ 
│   on variables.tf line 62, in variable "cloud":
│   62:     error_message = "Allowed values are: ${join(", ", local.clouds)}."
│ 
│ The local value local.clouds was not processed by the most recent
│ operation, this likely means the previous operation either failed or was
│ incomplete due to targeting.
```

## Solution
<!-- A summary of the solution addressing the above issue -->
Static validation in the variable now passes.

### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This does not affect the deployment, and only fixes the tests in CI.

Similar to this change, but on the `main` branch:
- https://github.com/canonical/observability-stack/pull/315/changes#diff-064ac93c7365220932a8a160c55e4d49d2002599fc92e37ac7bd07ed9ccfd354
