### PR TITLE
fix(track/2): Traefik refresh bug in cross-track upgrades

### DIFF
--- a/terraform/cos-lite/upgrades.tf
+++ b/terraform/cos-lite/upgrades.tf
@@ -39,5 +39,5 @@ data "juju_charm" "grafana_info" {
 data "juju_charm" "traefik_info" {
   charm   = "traefik-k8s"
   channel = var.traefik.channel
-  base    = "ubuntu@24.04"
+  base    = "ubuntu@20.04"
 }

--- a/terraform/cos-lite/upgrades.tf
+++ b/terraform/cos-lite/upgrades.tf
@@ -35,3 +35,9 @@ data "juju_charm" "grafana_info" {
   channel = var.channel
   base    = "ubuntu@24.04"
 }
+
+data "juju_charm" "traefik_info" {
+  charm   = "traefik-k8s"
+  channel = var.traefik.channel
+  base    = "ubuntu@24.04"
+}

--- a/terraform/cos-lite/upgrades.tf
+++ b/terraform/cos-lite/upgrades.tf
@@ -18,6 +18,16 @@ resource "terraform_data" "grafana_ingress_interface" {
   triggers_replace = lookup(data.juju_charm.grafana_info.requires, "ingress", "")
 }
 
+# -- Traefik -- #
+
+# [integration] Malformed cert on upgrade
+#   When upgraded, traefik's certificate is written to disk with double-quotes
+#   causing 500 errors when using ingress since Traefik doesn't trust the cert.
+#   https://github.com/canonical/traefik-k8s-operator/issues/668
+resource "terraform_data" "traefik_revision" {
+  triggers_replace = data.juju_charm.traefik_info.revision
+}
+
 # -------------- # CharmHub API -------------- #
 
 data "juju_charm" "grafana_info" {

--- a/terraform/cos/upgrades.tf
+++ b/terraform/cos/upgrades.tf
@@ -18,10 +18,26 @@ resource "terraform_data" "grafana_ingress_interface" {
   triggers_replace = lookup(data.juju_charm.grafana_info.requires, "ingress", "")
 }
 
+# -- Traefik -- #
+
+# [integration] Malformed cert on upgrade
+#   When upgraded, traefik's certificate is written to disk with double-quotes
+#   causing 500 errors when using ingress since Traefik doesn't trust the cert.
+#   https://github.com/canonical/traefik-k8s-operator/issues/668
+resource "terraform_data" "traefik_revision" {
+  triggers_replace = data.juju_charm.traefik_info.revision
+}
+
 # -------------- # CharmHub API -------------- #
 
 data "juju_charm" "grafana_info" {
   charm   = "grafana-k8s"
   channel = var.channel
   base    = "ubuntu@24.04"
+}
+
+data "juju_charm" "traefik_info" {
+  charm   = "traefik-k8s"
+  channel = var.traefik.channel
+  base    = "ubuntu@20.04"
 }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Workaround for this issue:
- https://github.com/canonical/traefik-k8s-operator/issues/668

This is adding the `terraform_data` resource to the `track/2` module so our users will have it in their COS TF state. This PR is blocking this one into main:
- https://github.com/canonical/observability-stack/pull/320

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
See the integration tests in this PR for confidence that this PR is valid:
- https://github.com/canonical/observability-stack/pull/320

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
A `terraform apply` will include the new resources in our user's state and will not affect their COS components.