### PR TITLE
feat: Add Loki logging integrations

### DIFF
--- a/terraform/cos-lite/integrations.tf
+++ b/terraform/cos-lite/integrations.tf
@@ -160,6 +160,34 @@ resource "juju_integration" "loki_self_monitoring_prometheus" {
   }
 }
 
+resource "juju_integration" "loki_logging" {
+  for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.requires.logging
+    }
+    grafana = {
+      app_name = module.grafana.app_name
+      endpoint = module.grafana.requires.logging
+    }
+    prometheus = {
+      app_name = module.prometheus.app_name
+      endpoint = module.prometheus.requires.logging
+    }
+  }
+  model_uuid = var.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.loki.app_name
+    endpoint = module.loki.provides.logging
+  }
+}
+
 # -------------- # Provided by Catalogue --------------
 
 resource "juju_integration" "catalogue_alertmanager" {

--- a/terraform/cos/integrations.tf
+++ b/terraform/cos/integrations.tf
@@ -113,8 +113,8 @@ resource "juju_integration" "otelcol_metrics_endpoint" {
   }
 }
 
-
 # -------------- # Grafana Source Integrations --------------
+
 resource "juju_integration" "grafana_sources" {
   for_each = {
     alertmanager = {
@@ -154,6 +154,14 @@ resource "juju_integration" "grafana_sources" {
 
 resource "juju_integration" "otelcol_logging_provider" {
   for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.requires.logging
+    }
+    grafana = {
+      app_name = module.grafana.app_name
+      endpoint = module.grafana.requires.logging
+    }
     mimir = {
       app_name = module.mimir.app_names.mimir_coordinator
       endpoint = module.mimir.requires.logging_consumer
@@ -179,6 +187,7 @@ resource "juju_integration" "otelcol_logging_provider" {
     endpoint = module.opentelemetry_collector.provides.receive_loki_logs
   }
 }
+
 # -------- Provided by Alertmanager --------------
 
 resource "juju_integration" "alerting" {


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/observability-stack/issues/312

## Solution
<!-- A summary of the solution addressing the above issue -->
### COS
```mermaid
flowchart LR
    AM[alertmanager]
    GF[grafana]
    MI[mimir-coordinator]
    LK[loki-coordinator]
    TP[tempo-coordinator]
    OT[otelcol]
    LKS[(loki-coordinator)]

    AM -- logging --> OT
    GF -- logging --> OT
    MI -- logging_consumer --> OT
    LK -- logging_consumer --> OT
    TP -- logging --> OT
    OT -- send_loki_logs --> LKS
```
### COS Lite
```mermaid
flowchart LR
    AM[alertmanager]
    GF[grafana]
    PR[prometheus]
    LK[(loki)]

    AM -- logging --> LK
    GF -- logging --> LK
    PR -- logging --> LK
```

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Assert that the CI passes, checking for:
- static validation of integrations
- cross-track upgrades

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
Next `terraform apply`, users will now obtain the logging integrations, withouth changes to the original COS resources.