### PR TITLE
fix: Remove the Traefik patch in upgrades.tf

### DIFF
--- a/terraform/cos-lite/integrations.tf
+++ b/terraform/cos-lite/integrations.tf
@@ -410,8 +410,6 @@ resource "juju_integration" "traefik_receive_ca_certificate" {
     name     = module.traefik.app_name
     endpoint = module.traefik.endpoints.receive_ca_cert
   }
-
-  lifecycle { replace_triggered_by = [terraform_data.traefik_revision] }
 }
 
 # -------------- # Provided by an external CA --------------

--- a/terraform/cos-lite/upgrades.tf
+++ b/terraform/cos-lite/upgrades.tf
@@ -18,16 +18,6 @@ resource "terraform_data" "grafana_ingress_interface" {
   triggers_replace = lookup(data.juju_charm.grafana_info.requires, "ingress", "")
 }
 
-# -- Traefik -- #
-
-# [integration] Malformed cert on upgrade
-#   When upgraded, traefik's certificate is written to disk with double-quotes
-#   causing 500 errors when using ingress since Traefik doesn't trust the cert.
-#   https://github.com/canonical/traefik-k8s-operator/issues/668
-resource "terraform_data" "traefik_revision" {
-  triggers_replace = data.juju_charm.traefik_info.revision
-}
-
 # -------------- # CharmHub API -------------- #
 
 data "juju_charm" "alertmanager_info" {

--- a/terraform/cos/integrations.tf
+++ b/terraform/cos/integrations.tf
@@ -467,8 +467,6 @@ resource "juju_integration" "traefik_receive_ca_certificate" {
     name     = module.traefik.app_name
     endpoint = module.traefik.endpoints.receive_ca_cert
   }
-
-  lifecycle { replace_triggered_by = [terraform_data.traefik_revision] }
 }
 
 # -------------- # Provided by an external CA --------------

--- a/terraform/cos/upgrades.tf
+++ b/terraform/cos/upgrades.tf
@@ -18,16 +18,6 @@ resource "terraform_data" "grafana_ingress_interface" {
   triggers_replace = lookup(data.juju_charm.grafana_info.requires, "ingress", "")
 }
 
-# -- Traefik -- #
-
-# [integration] Malformed cert on upgrade
-#   When upgraded, traefik's certificate is written to disk with double-quotes
-#   causing 500 errors when using ingress since Traefik doesn't trust the cert.
-#   https://github.com/canonical/traefik-k8s-operator/issues/668
-resource "terraform_data" "traefik_revision" {
-  triggers_replace = data.juju_charm.traefik_info.revision
-}
-
 # -------------- # CharmHub API -------------- #
 
 data "juju_charm" "alertmanager_info" {

--- a/tests/integration/cos/tls_full/track-2.tf
+++ b/tests/integration/cos/tls_full/track-2.tf
@@ -44,7 +44,7 @@ module "ssc" {
 }
 
 module "cos" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/2"
+  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=fix/remove-traefik-patch-track-2"
   model_uuid                      = data.juju_model.cos-model.uuid
   channel                         = "2/stable"
   internal_tls                    = true

--- a/tests/integration/cos/tls_full/track-dev.tf
+++ b/tests/integration/cos/tls_full/track-dev.tf
@@ -44,7 +44,7 @@ module "ssc" {
 }
 
 module "cos" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos"
+  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=fix/remove-traefik-patch"
   model_uuid                      = data.juju_model.cos-model.uuid
   risk                            = "edge"
   internal_tls                    = true

--- a/tests/integration/cos/tls_internal/track-2.tf
+++ b/tests/integration/cos/tls_internal/track-2.tf
@@ -30,7 +30,7 @@ variable "s3_access_key" {
 }
 
 module "cos" {
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/2"
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=fix/remove-traefik-patch-track-2"
   model_uuid   = data.juju_model.model.uuid
   channel      = "2/stable"
   internal_tls = true

--- a/tests/integration/cos/tls_internal/track-dev.tf
+++ b/tests/integration/cos/tls_internal/track-dev.tf
@@ -30,7 +30,7 @@ variable "s3_access_key" {
 }
 
 module "cos" {
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos"
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=fix/remove-traefik-patch"
   model_uuid   = data.juju_model.model.uuid
   risk         = "edge"
   internal_tls = true

--- a/tests/integration/cos_lite/tls_full/track-2.tf
+++ b/tests/integration/cos_lite/tls_full/track-2.tf
@@ -32,7 +32,7 @@ module "ssc" {
 }
 
 module "cos-lite" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2"
+  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=fix/remove-traefik-patch-track-2"
   model_uuid                      = data.juju_model.cos-model.uuid
   channel                         = "2/stable"
   internal_tls                    = true

--- a/tests/integration/cos_lite/tls_full/track-dev.tf
+++ b/tests/integration/cos_lite/tls_full/track-dev.tf
@@ -32,7 +32,7 @@ module "ssc" {
 }
 
 module "cos-lite" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite"
+  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=fix/remove-traefik-patch"
   model_uuid                      = data.juju_model.cos-model.uuid
   risk                            = "edge"
   internal_tls                    = true

--- a/tests/integration/cos_lite/tls_internal/track-2.tf
+++ b/tests/integration/cos_lite/tls_internal/track-2.tf
@@ -18,7 +18,7 @@ data "juju_model" "model" {
 }
 
 module "cos-lite" {
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2"
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=fix/remove-traefik-patch-track-2"
   model_uuid   = data.juju_model.model.uuid
   channel      = "2/stable"
   internal_tls = true

--- a/tests/integration/cos_lite/tls_internal/track-dev.tf
+++ b/tests/integration/cos_lite/tls_internal/track-dev.tf
@@ -18,7 +18,7 @@ data "juju_model" "model" {
 }
 
 module "cos-lite" {
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite"
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=fix/remove-traefik-patch"
   model_uuid   = data.juju_model.model.uuid
   risk         = "edge"
   internal_tls = true


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This issue was fixed in Traefik:
- https://github.com/canonical/traefik-k8s-operator/issues/668

## Solution
<!-- A summary of the solution addressing the above issue -->
So we can undo the patch from this PR:
- https://github.com/canonical/observability-stack/pull/320

In tandem with this one into track/2:
- https://github.com/canonical/observability-stack/pull/329

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
