### PR TITLE
fix(track/2): Remove the Traefik patch in upgrades.tf

### DIFF
--- a/terraform/cos-lite/upgrades.tf
+++ b/terraform/cos-lite/upgrades.tf
@@ -18,26 +18,10 @@ resource "terraform_data" "grafana_ingress_interface" {
   triggers_replace = lookup(data.juju_charm.grafana_info.requires, "ingress", "")
 }
 
-# -- Traefik -- #
-
-# [integration] Malformed cert on upgrade
-#   When upgraded, traefik's certificate is written to disk with double-quotes
-#   causing 500 errors when using ingress since Traefik doesn't trust the cert.
-#   https://github.com/canonical/traefik-k8s-operator/issues/668
-resource "terraform_data" "traefik_revision" {
-  triggers_replace = data.juju_charm.traefik_info.revision
-}
-
 # -------------- # CharmHub API -------------- #
 
 data "juju_charm" "grafana_info" {
   charm   = "grafana-k8s"
   channel = var.channel
   base    = "ubuntu@24.04"
-}
-
-data "juju_charm" "traefik_info" {
-  charm   = "traefik-k8s"
-  channel = var.traefik.channel
-  base    = "ubuntu@20.04"
 }

--- a/terraform/cos/upgrades.tf
+++ b/terraform/cos/upgrades.tf
@@ -18,26 +18,10 @@ resource "terraform_data" "grafana_ingress_interface" {
   triggers_replace = lookup(data.juju_charm.grafana_info.requires, "ingress", "")
 }
 
-# -- Traefik -- #
-
-# [integration] Malformed cert on upgrade
-#   When upgraded, traefik's certificate is written to disk with double-quotes
-#   causing 500 errors when using ingress since Traefik doesn't trust the cert.
-#   https://github.com/canonical/traefik-k8s-operator/issues/668
-resource "terraform_data" "traefik_revision" {
-  triggers_replace = data.juju_charm.traefik_info.revision
-}
-
 # -------------- # CharmHub API -------------- #
 
 data "juju_charm" "grafana_info" {
   charm   = "grafana-k8s"
   channel = var.channel
   base    = "ubuntu@24.04"
-}
-
-data "juju_charm" "traefik_info" {
-  charm   = "traefik-k8s"
-  channel = var.traefik.channel
-  base    = "ubuntu@20.04"
 }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This issue was fixed in Traefik:
- https://github.com/canonical/traefik-k8s-operator/issues/668

## Solution
<!-- A summary of the solution addressing the above issue -->
So we can undo the patch from this PR:
- https://github.com/canonical/observability-stack/pull/322

In tandem with this one into main:
- https://github.com/canonical/observability-stack/pull/328

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
