### PR TITLE
chore: Revert TF itest branches

### DIFF
--- a/tests/integration/cos/tls_full/track-2.tf
+++ b/tests/integration/cos/tls_full/track-2.tf
@@ -44,7 +44,7 @@ module "ssc" {
 }
 
 module "cos" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=fix/remove-traefik-patch-track-2"
+  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/2"
   model_uuid                      = data.juju_model.cos-model.uuid
   channel                         = "2/stable"
   internal_tls                    = true

--- a/tests/integration/cos/tls_full/track-dev.tf
+++ b/tests/integration/cos/tls_full/track-dev.tf
@@ -44,7 +44,7 @@ module "ssc" {
 }
 
 module "cos" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=fix/remove-traefik-patch"
+  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos"
   model_uuid                      = data.juju_model.cos-model.uuid
   risk                            = "edge"
   internal_tls                    = true

--- a/tests/integration/cos/tls_internal/track-2.tf
+++ b/tests/integration/cos/tls_internal/track-2.tf
@@ -30,7 +30,7 @@ variable "s3_access_key" {
 }
 
 module "cos" {
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=fix/remove-traefik-patch-track-2"
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/2"
   model_uuid   = data.juju_model.model.uuid
   channel      = "2/stable"
   internal_tls = true

--- a/tests/integration/cos/tls_internal/track-dev.tf
+++ b/tests/integration/cos/tls_internal/track-dev.tf
@@ -30,7 +30,7 @@ variable "s3_access_key" {
 }
 
 module "cos" {
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=fix/remove-traefik-patch"
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos"
   model_uuid   = data.juju_model.model.uuid
   risk         = "edge"
   internal_tls = true

--- a/tests/integration/cos_lite/tls_full/track-2.tf
+++ b/tests/integration/cos_lite/tls_full/track-2.tf
@@ -32,7 +32,7 @@ module "ssc" {
 }
 
 module "cos-lite" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=fix/remove-traefik-patch-track-2"
+  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2"
   model_uuid                      = data.juju_model.cos-model.uuid
   channel                         = "2/stable"
   internal_tls                    = true

--- a/tests/integration/cos_lite/tls_full/track-dev.tf
+++ b/tests/integration/cos_lite/tls_full/track-dev.tf
@@ -32,7 +32,7 @@ module "ssc" {
 }
 
 module "cos-lite" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=fix/remove-traefik-patch"
+  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite"
   model_uuid                      = data.juju_model.cos-model.uuid
   risk                            = "edge"
   internal_tls                    = true

--- a/tests/integration/cos_lite/tls_internal/track-2.tf
+++ b/tests/integration/cos_lite/tls_internal/track-2.tf
@@ -18,7 +18,7 @@ data "juju_model" "model" {
 }
 
 module "cos-lite" {
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=fix/remove-traefik-patch-track-2"
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2"
   model_uuid   = data.juju_model.model.uuid
   channel      = "2/stable"
   internal_tls = true

--- a/tests/integration/cos_lite/tls_internal/track-dev.tf
+++ b/tests/integration/cos_lite/tls_internal/track-dev.tf
@@ -18,7 +18,7 @@ data "juju_model" "model" {
 }
 
 module "cos-lite" {
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=fix/remove-traefik-patch"
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite"
   model_uuid   = data.juju_model.model.uuid
   risk         = "edge"
   internal_tls = true


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Revert the branches used in this PR:
- https://github.com/canonical/observability-stack/pull/328

to get the itests to pass.