### PR TITLE
fix: update link to Microceph hardening overview doc

### DIFF
--- a/docs/reference/security-hardening-guide.md
+++ b/docs/reference/security-hardening-guide.md
@@ -14,7 +14,7 @@ COS can only be as secure as what it is deployed on.  To ensure your substrate i
 
 * [Juju Security](https://documentation.ubuntu.com/juju/latest/user/explanation/juju-security/)
 * [Securing Canonical Kubernetes](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/security/hardening/)
-* [MicroCeph security overview](https://canonical-microceph.readthedocs-hosted.com/stable/explanation/security/security-overview/)
+* [MicroCeph security overview](https://canonical-microceph.readthedocs-hosted.com/stable/snap/explanation/security/security-overview/)
 
 ## Secure COS
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Updates the link to the Microceph docs on security overview, which were recently changed. Unblocks CI for #337.

## Solution
<!-- A summary of the solution addressing the above issue -->

### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
