### PR TITLE
docs: fix cookie notification

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,8 +206,8 @@ sitemap_excludes = [
 # Template and asset locations #
 ################################
 
-# html_static_path = ["_static"]
-# templates_path = ["_templates"]
+html_static_path = [".sphinx/_static"]
+templates_path = [".sphinx/_templates"]
 
 
 #############
@@ -308,16 +308,16 @@ exclude_patterns = [
 
 # Adds custom CSS files, located under 'html_static_path'
 
-# html_css_files = [
-#     "https://assets.ubuntu.com/v1/d86746ef-cookie_banner.css",
-# ]
+html_css_files = [
+    "cookie-banner.css",
+]
 
 
 # Adds custom JavaScript files, located under 'html_static_path'
 
-# html_js_files = [
-#     "https://assets.ubuntu.com/v1/287a5e8f-bundle.js",
-# ]
+html_js_files = [
+    "bundle.js",
+ ]
 
 
 # Specifies a reST snippet to be appended to each .rst file


### PR DESCRIPTION
## Issue
Fixing the cookie notification, accidentally removed it in #237 

## Solution
Added the cookie notification link (updated to the new location)

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 

## Testing Instructions
Run it in incognito mode if you don't see the notification popup when you test. 
