### PR TITLE
feat: strip "$ " shell prompts from copy button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -299,6 +299,15 @@ extensions = [
 
 mathjax_path = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'
 
+# Configure sphinx-copybutton (auto-enabled by canonical_sphinx) to strip
+# the "$ " shell prompt from copied content. In code blocks that contain
+# prompts, only the prompted lines (commands) are copied; output lines are
+# skipped. Code blocks without any prompts (e.g. JSON output) are unaffected
+# and copy verbatim.
+copybutton_prompt_text = r"\$ "
+copybutton_prompt_is_regexp = True
+copybutton_line_continuation_character = "\\"
+
 # Excludes files or directories from processing
 
 exclude_patterns = [


### PR DESCRIPTION
## Issue

Copying a `$ command` block from our docs pastes the `$ ` along with it, which then fails when run in a real shell. Affects every shell code block across the site.

## Solution

Adds two lines to `docs/conf.py` configuring `sphinx-copybutton` to strip the `$ ` prompt on copy. Also sets `copybutton_line_continuation_character = "\\"` so multi-line commands joined by `\` copy as a single command.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.

## Context

`sphinx-copybutton` (auto-enabled by `canonical_sphinx`) supports prompt-stripping but doesn't apply it by default. With `copybutton_prompt_text = r"\$ "` and `copybutton_prompt_is_regexp = True`, blocks containing `$ `-prefixed lines copy only the command portion, and blocks without prompts (e.g. JSON output) copy verbatim.

Aligns with the [[Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en/)](https://docs.ubuntu.com/styleguide/en/), which advises against prompt marks in code samples for this exact reason.

## Testing Instructions

1. `cd docs && make clean && make serve`
2. Open any tutorial page, find a `$ ` shell block, click the copy button.
3. Paste somewhere — should yield `command` not `$ command`.
4. Verify a JSON or output-only block still copies verbatim.

## Upgrade Notes

None — additive config-only change. No content or build-pipeline changes.