### PR TITLE
feat: Generic COS assertions function

### DIFF
--- a/terraform/cos/locals.tf
+++ b/terraform/cos/locals.tf
@@ -1,4 +1,3 @@
-# TODO: only for testing - remove
 locals {
   clouds          = ["aws", "self-managed"] # list of k8s clouds where this COS module can be deployed.
   tls_termination = var.external_certificates_offer_url != null ? true : false

--- a/terraform/cos/locals.tf
+++ b/terraform/cos/locals.tf
@@ -1,3 +1,4 @@
+# TODO: only for testing - remove
 locals {
   clouds          = ["aws", "self-managed"] # list of k8s clouds where this COS module can be deployed.
   tls_termination = var.external_certificates_offer_url != null ? true : false

--- a/tests/integration/cos/tls_external/test_upgrade_cos_tls_external.py
+++ b/tests/integration/cos/tls_external/test_upgrade_cos_tls_external.py
@@ -8,12 +8,7 @@ import os
 from pathlib import Path
 
 import jubilant
-from helpers import (
-    catalogue_apps_are_reachable,
-    get_tls_context,
-    no_errors_in_otelcol_logs,
-    wait_for_active_idle_without_error,
-)
+from helpers import generic_assertions, no_errors_in_otelcol_logs
 
 TRACK_2_TF_FILE = Path(__file__).parent.resolve() / "track-2.tf"
 TRACK_DEV_TF_FILE = Path(__file__).parent.resolve() / "track-dev.tf"
@@ -36,9 +31,7 @@ def test_deploy_from_track_2(
     # GIVEN a module deployed from track 2
     tf_manager.init(TRACK_2_TF_FILE)
     tf_manager.apply(ca_model=ca_model.model, cos_model=cos_model.model, **S3_ENDPOINT)
-    wait_for_active_idle_without_error([cos_model], timeout=5400)
-    tls_ctx = get_tls_context(tmp_path, ca_model, "self-signed-certificates")
-    catalogue_apps_are_reachable(cos_model, tls_ctx)
+    generic_assertions(cos_model, ca_model, tmp_path)
     no_errors_in_otelcol_logs(cos_model)
 
 
@@ -50,7 +43,5 @@ def test_deploy_to_track_dev(
     tf_manager.apply(ca_model=ca_model.model, cos_model=cos_model.model, **S3_ENDPOINT)
 
     # THEN the model is upgraded and is healthy
-    wait_for_active_idle_without_error([ca_model, cos_model])
-    tls_ctx = get_tls_context(tmp_path, ca_model, "self-signed-certificates")
-    catalogue_apps_are_reachable(cos_model, tls_ctx)
+    generic_assertions(cos_model, ca_model, tmp_path)
     no_errors_in_otelcol_logs(cos_model)

--- a/tests/integration/cos/tls_full/test_upgrade_cos_tls_full.py
+++ b/tests/integration/cos/tls_full/test_upgrade_cos_tls_full.py
@@ -8,12 +8,7 @@ import os
 from pathlib import Path
 
 import jubilant
-from helpers import (
-    catalogue_apps_are_reachable,
-    get_tls_context,
-    no_errors_in_otelcol_logs,
-    wait_for_active_idle_without_error,
-)
+from helpers import generic_assertions, no_errors_in_otelcol_logs
 
 TRACK_2_TF_FILE = Path(__file__).parent.resolve() / "track-2.tf"
 TRACK_DEV_TF_FILE = Path(__file__).parent.resolve() / "track-dev.tf"
@@ -36,9 +31,7 @@ def test_deploy_from_track_2(
     # GIVEN a module deployed from track 2
     tf_manager.init(TRACK_2_TF_FILE)
     tf_manager.apply(ca_model=ca_model.model, cos_model=cos_model.model, **S3_ENDPOINT)
-    wait_for_active_idle_without_error([cos_model], timeout=5400)
-    tls_ctx = get_tls_context(tmp_path, ca_model, "self-signed-certificates")
-    catalogue_apps_are_reachable(cos_model, tls_ctx)
+    generic_assertions(cos_model, ca_model, tmp_path)
     no_errors_in_otelcol_logs(cos_model)
 
 
@@ -50,7 +43,5 @@ def test_deploy_to_track_dev(
     tf_manager.apply(ca_model=ca_model.model, cos_model=cos_model.model, **S3_ENDPOINT)
 
     # THEN the model is upgraded and is healthy
-    wait_for_active_idle_without_error([ca_model, cos_model])
-    tls_ctx = get_tls_context(tmp_path, ca_model, "self-signed-certificates")
-    catalogue_apps_are_reachable(cos_model, tls_ctx)
+    generic_assertions(cos_model, ca_model, tmp_path)
     no_errors_in_otelcol_logs(cos_model)

--- a/tests/integration/cos/tls_internal/test_upgrade_cos_tls_internal.py
+++ b/tests/integration/cos/tls_internal/test_upgrade_cos_tls_internal.py
@@ -8,11 +8,7 @@ import os
 from pathlib import Path
 
 import jubilant
-from helpers import (
-    catalogue_apps_are_reachable,
-    no_errors_in_otelcol_logs,
-    wait_for_active_idle_without_error,
-)
+from helpers import generic_assertions, no_errors_in_otelcol_logs
 
 TRACK_2_TF_FILE = Path(__file__).parent.resolve() / "track-2.tf"
 TRACK_DEV_TF_FILE = Path(__file__).parent.resolve() / "track-dev.tf"
@@ -33,8 +29,7 @@ def test_deploy_from_track_2(tf_manager, cos_model: jubilant.Juju):
     # GIVEN a module deployed from track 2
     tf_manager.init(TRACK_2_TF_FILE)
     tf_manager.apply(model=cos_model.model, **S3_ENDPOINT)
-    wait_for_active_idle_without_error([cos_model], timeout=5400)
-    catalogue_apps_are_reachable(cos_model)
+    generic_assertions(cos_model)
     no_errors_in_otelcol_logs(cos_model)
 
 
@@ -44,6 +39,5 @@ def test_deploy_to_track_dev(tf_manager, cos_model: jubilant.Juju):
     tf_manager.apply(model=cos_model.model, **S3_ENDPOINT)
 
     # THEN the model is upgraded and is healthy
-    wait_for_active_idle_without_error([cos_model])
-    catalogue_apps_are_reachable(cos_model)
+    generic_assertions(cos_model)
     no_errors_in_otelcol_logs(cos_model)

--- a/tests/integration/cos/tls_none/test_upgrade_cos_tls_none.py
+++ b/tests/integration/cos/tls_none/test_upgrade_cos_tls_none.py
@@ -8,11 +8,7 @@ import os
 from pathlib import Path
 
 import jubilant
-from helpers import (
-    catalogue_apps_are_reachable,
-    no_errors_in_otelcol_logs,
-    wait_for_active_idle_without_error,
-)
+from helpers import generic_assertions, no_errors_in_otelcol_logs
 
 TRACK_2_TF_FILE = Path(__file__).parent.resolve() / "track-2.tf"
 TRACK_DEV_TF_FILE = Path(__file__).parent.resolve() / "track-dev.tf"
@@ -33,8 +29,7 @@ def test_deploy_from_track_2(tf_manager, cos_model: jubilant.Juju):
     # GIVEN a module deployed from track 2
     tf_manager.init(TRACK_2_TF_FILE)
     tf_manager.apply(model=cos_model.model, **S3_ENDPOINT)
-    wait_for_active_idle_without_error([cos_model], timeout=5400)
-    catalogue_apps_are_reachable(cos_model)
+    generic_assertions(cos_model)
     no_errors_in_otelcol_logs(cos_model)
 
 
@@ -44,6 +39,5 @@ def test_deploy_to_track_dev(tf_manager, cos_model: jubilant.Juju):
     tf_manager.apply(model=cos_model.model, **S3_ENDPOINT)
 
     # THEN the model is upgraded and is healthy
-    wait_for_active_idle_without_error([cos_model])
-    catalogue_apps_are_reachable(cos_model)
+    generic_assertions(cos_model)
     no_errors_in_otelcol_logs(cos_model)

--- a/tests/integration/cos_lite/tls_external/test_upgrade_cos_lite_tls_external.py
+++ b/tests/integration/cos_lite/tls_external/test_upgrade_cos_lite_tls_external.py
@@ -7,11 +7,7 @@ https://documentation.ubuntu.com/observability/latest/how-to/configure-tls-encry
 from pathlib import Path
 
 import jubilant
-from helpers import (
-    catalogue_apps_are_reachable,
-    get_tls_context,
-    wait_for_active_idle_without_error,
-)
+from helpers import generic_assertions
 
 TRACK_2_TF_FILE = Path(__file__).parent.resolve() / "track-2.tf"
 TRACK_DEV_TF_FILE = Path(__file__).parent.resolve() / "track-dev.tf"
@@ -23,9 +19,7 @@ def test_deploy_from_track_2(
     # GIVEN a module deployed from track 2
     tf_manager.init(TRACK_2_TF_FILE)
     tf_manager.apply(ca_model=ca_model.model, cos_model=cos_model.model)
-    wait_for_active_idle_without_error([ca_model, cos_model], timeout=60 * 60)
-    tls_ctx = get_tls_context(tmp_path, ca_model, "self-signed-certificates")
-    catalogue_apps_are_reachable(cos_model, tls_ctx)
+    generic_assertions(cos_model, ca_model, tmp_path)
 
 
 def test_deploy_to_track_dev(
@@ -36,6 +30,4 @@ def test_deploy_to_track_dev(
     tf_manager.apply(ca_model=ca_model.model, cos_model=cos_model.model)
 
     # THEN the model is upgraded and is healthy
-    wait_for_active_idle_without_error([ca_model, cos_model])
-    tls_ctx = get_tls_context(tmp_path, ca_model, "self-signed-certificates")
-    catalogue_apps_are_reachable(cos_model, tls_ctx)
+    generic_assertions(cos_model, ca_model, tmp_path)

--- a/tests/integration/cos_lite/tls_full/test_upgrade_cos_lite_tls_full.py
+++ b/tests/integration/cos_lite/tls_full/test_upgrade_cos_lite_tls_full.py
@@ -7,11 +7,7 @@ https://documentation.ubuntu.com/observability/latest/how-to/configure-tls-encry
 from pathlib import Path
 
 import jubilant
-from helpers import (
-    catalogue_apps_are_reachable,
-    get_tls_context,
-    wait_for_active_idle_without_error,
-)
+from helpers import generic_assertions
 
 TRACK_2_TF_FILE = Path(__file__).parent.resolve() / "track-2.tf"
 TRACK_DEV_TF_FILE = Path(__file__).parent.resolve() / "track-dev.tf"
@@ -23,9 +19,7 @@ def test_deploy_from_track_2(
     # GIVEN a module deployed from track 2
     tf_manager.init(TRACK_2_TF_FILE)
     tf_manager.apply(ca_model=ca_model.model, cos_model=cos_model.model)
-    wait_for_active_idle_without_error([ca_model, cos_model], timeout=60 * 60)
-    tls_ctx = get_tls_context(tmp_path, ca_model, "self-signed-certificates")
-    catalogue_apps_are_reachable(cos_model, tls_ctx)
+    generic_assertions(cos_model, ca_model, tmp_path)
 
 
 def test_deploy_to_track_dev(
@@ -36,6 +30,4 @@ def test_deploy_to_track_dev(
     tf_manager.apply(ca_model=ca_model.model, cos_model=cos_model.model)
 
     # THEN the model is upgraded and is healthy
-    wait_for_active_idle_without_error([ca_model, cos_model])
-    tls_ctx = get_tls_context(tmp_path, ca_model, "self-signed-certificates")
-    catalogue_apps_are_reachable(cos_model, tls_ctx)
+    generic_assertions(cos_model, ca_model, tmp_path)

--- a/tests/integration/cos_lite/tls_internal/test_upgrade_cos_lite_tls_internal.py
+++ b/tests/integration/cos_lite/tls_internal/test_upgrade_cos_lite_tls_internal.py
@@ -7,7 +7,7 @@ https://documentation.ubuntu.com/observability/latest/how-to/configure-tls-encry
 from pathlib import Path
 
 import jubilant
-from helpers import catalogue_apps_are_reachable, wait_for_active_idle_without_error
+from helpers import generic_assertions
 
 TRACK_2_TF_FILE = Path(__file__).parent.resolve() / "track-2.tf"
 TRACK_DEV_TF_FILE = Path(__file__).parent.resolve() / "track-dev.tf"
@@ -17,8 +17,7 @@ def test_deploy_from_track_2(tf_manager, cos_model: jubilant.Juju):
     # GIVEN a module deployed from track 2
     tf_manager.init(TRACK_2_TF_FILE)
     tf_manager.apply(model=cos_model.model)
-    wait_for_active_idle_without_error([cos_model], timeout=60 * 60)
-    catalogue_apps_are_reachable(cos_model)
+    generic_assertions(cos_model)
 
 
 def test_deploy_to_track_dev(tf_manager, cos_model: jubilant.Juju):
@@ -27,5 +26,4 @@ def test_deploy_to_track_dev(tf_manager, cos_model: jubilant.Juju):
     tf_manager.apply(model=cos_model.model)
 
     # THEN the model is upgraded and is healthy
-    wait_for_active_idle_without_error([cos_model])
-    catalogue_apps_are_reachable(cos_model)
+    generic_assertions(cos_model)

--- a/tests/integration/cos_lite/tls_none/test_upgrade_cos_lite_tls_none.py
+++ b/tests/integration/cos_lite/tls_none/test_upgrade_cos_lite_tls_none.py
@@ -7,7 +7,7 @@ https://documentation.ubuntu.com/observability/latest/how-to/configure-tls-encry
 from pathlib import Path
 
 import jubilant
-from helpers import catalogue_apps_are_reachable, wait_for_active_idle_without_error
+from helpers import generic_assertions
 
 TRACK_2_TF_FILE = Path(__file__).parent.resolve() / "track-2.tf"
 TRACK_DEV_TF_FILE = Path(__file__).parent.resolve() / "track-dev.tf"
@@ -17,8 +17,7 @@ def test_deploy_from_track_2(tf_manager, cos_model: jubilant.Juju):
     # GIVEN a module deployed from track 2
     tf_manager.init(TRACK_2_TF_FILE)
     tf_manager.apply(model=cos_model.model)
-    wait_for_active_idle_without_error([cos_model], timeout=60 * 60)
-    catalogue_apps_are_reachable(cos_model)
+    generic_assertions(cos_model)
 
 
 def test_deploy_to_track_dev(tf_manager, cos_model: jubilant.Juju):
@@ -27,5 +26,4 @@ def test_deploy_to_track_dev(tf_manager, cos_model: jubilant.Juju):
     tf_manager.apply(model=cos_model.model)
 
     # THEN the model is upgraded and is healthy
-    wait_for_active_idle_without_error([cos_model])
-    catalogue_apps_are_reachable(cos_model)
+    generic_assertions(cos_model)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -43,6 +43,21 @@ class TfDirManager:
         subprocess.run(shlex.split(cmd_str), check=True)
 
 
+def generic_assertions(
+    cos_model: jubilant.Juju,
+    ca_model: jubilant.Juju | None = None,
+    temp_path: Path | None = None,
+):
+    # generic assertions that are shared between products: cos, cos-lite
+    wait_for_active_idle_without_error([ca_model, cos_model], timeout=60 * 60)
+    if ca_model:
+        assert temp_path is not None, "temp_path is required when ca_model is provided"
+        tls_ctx = get_tls_context(temp_path, ca_model, "self-signed-certificates")
+    else:
+        tls_ctx = None
+    catalogue_apps_are_reachable(cos_model, tls_ctx)
+
+
 def wait_for_active_idle_without_error(
     jujus: List[jubilant.Juju], timeout: int = 60 * 45
 ):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We have many tests doing the same assertions.

## Solution
<!-- A summary of the solution addressing the above issue -->
In attempt to be more DRY I added a `generic_assertions` free function that accepts the correct args to execute all the assertions agnostic to the product flavors:
- COS
- COS Lite
- COS Dev

Any assertions that are specific to a flavor should remain free and called in relevant tests e.g., `no_errors_in_otelcol_logs` because COS Lite has no otelcol app.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
