### PR TITLE
fix: Generic itest assertions conditional

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -48,13 +48,12 @@ def generic_assertions(
     ca_model: jubilant.Juju | None = None,
     temp_path: Path | None = None,
 ):
-    # generic assertions that are shared between products: cos, cos-lite
-    wait_for_active_idle_without_error([ca_model, cos_model], timeout=60 * 60)
-    if ca_model:
-        assert temp_path is not None, "temp_path is required when ca_model is provided"
-        tls_ctx = get_tls_context(temp_path, ca_model, "self-signed-certificates")
-    else:
-        tls_ctx = None
+    """Generic assertions that are shared between products: cos, cos-lite"""
+    if ca_model is not None and temp_path is None:
+        raise ValueError("temp_path is required when ca_model is provided")
+    models = [ca_model, cos_model] if ca_model is not None else [cos_model]
+    wait_for_active_idle_without_error(models, timeout=60 * 60)
+    tls_ctx = get_tls_context(temp_path, ca_model, "self-signed-certificates") if ca_model is not None else None
     catalogue_apps_are_reachable(cos_model, tls_ctx)
 
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The conditional did not account for the case where there is no ca_model and would fail itests for internal_tls and tls_none.

## Solution
<!-- A summary of the solution addressing the above issue -->
Update the conditional to handle all itest scenarios.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 