### PR TITLE
feat: Gated CI tests

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -46,6 +46,7 @@ jobs:
         run: just validate-terraform
   test-unit:
     name: Terraform unit tests
+    needs: [lint-terraform, lint-terraform-docs, validate-terraform]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,18 +59,21 @@ jobs:
         run: just unit
   test-integration-cos-lite:
     name: COS Lite Terraform integration
+    needs: [test-unit]
     uses: canonical/observability-stack/.github/workflows/_integration.yml@main
     with:
       product: cos_lite
       runner: self-hosted-linux-amd64-noble-large
   test-integration-cos:
     name: COS Terraform integration
+    needs: [test-unit]
     uses: canonical/observability-stack/.github/workflows/_integration.yml@main
     with:
       product: cos
       runner: self-hosted-linux-amd64-noble-xlarge
   test-integration-cos-dev:
     name: COS Dev Terraform integration
+    needs: [test-unit]
     uses: canonical/observability-stack/.github/workflows/_integration.yml@main
     with:
       product: cos_dev


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We should not run expensive tests unconditionally.

## Solution
<!-- A summary of the solution addressing the above issue -->
If a user has not formatted the Terraform modules, then do not run expensive unit tests and integration tests. Additionally, integration tests only run on successful unit tests.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
