### PR TITLE
docs: Explain conditional internal components

### DIFF
--- a/docs/how-to/deploy-and-manage/configure-granular-ingress.md
+++ b/docs/how-to/deploy-and-manage/configure-granular-ingress.md
@@ -52,4 +52,6 @@ Using the following Terraform module, set your ingress options to enable or disa
 ```{literalinclude} /how-to/deploy-and-manage/cos-ingress.tf
 ```
 
+The `ingress` variable determines if a COS-internal `traefik` application is deployed and integrated with COS components for ingress. If at least one application is configured for ingress, then `traefik` will exist internally, otherwise not.
+
 Ensure that you have provided any required variables (update the `... other inputs ...` placeholder) for the respective COS module before applying the configuration, by running `terraform apply`.

--- a/docs/how-to/deploy-and-manage/configure-tls-encryption.md
+++ b/docs/how-to/deploy-and-manage/configure-tls-encryption.md
@@ -90,7 +90,7 @@ The S3-integrator charm exposes a [tls-ca-chain option](https://charmhub.io/s3-i
 
 ## Deployment
 
-Using the following Terraform root module, you can control `external` and `internal` TLS. 
+Using the following Terraform root module, you can control `external` and `internal` TLS.
 
 To enable `internal` TLS, set the `internal_tls` value to `true`. To enable `external` TLS, supply the `external_certificates_offer_url` value with a `certificates` provider's Juju offer URL, from the `ssc` module in this example. The combination of these settings enables full encryption.
 
@@ -103,3 +103,6 @@ The [COS Lite bundle](https://charmhub.io/cos-lite) is now deprecated in favor o
 ```{literalinclude} /how-to/deploy-and-manage/cos-tls.tf
 ```
 
+The `internal_tls` variable determines if a COS-internal `self-signed-certificates` application is deployed and integrated with COS components for TLS.
+
+Ensure that you have provided any required variables (update the `... other inputs ...` placeholder) for the respective COS module before applying the configuration, by running `terraform apply`.

--- a/docs/how-to/deploy-and-manage/cos-tls.tf
+++ b/docs/how-to/deploy-and-manage/cos-tls.tf
@@ -9,6 +9,8 @@ module "cos" {
   risk         = "edge"
   internal_tls = true # TLS between in-model applications
 
+  # ... other inputs ...
+
   # Update the _offer_url inputs with the offered endpoints of the external CA's model
   external_certificates_offer_url = "admin/external-ca-model.certificates" # Set to 'null' to communicate with Traefik via HTTP, i.e. no 'external_tls'
   external_ca_cert_offer_url      = "admin/external-ca-model.send-ca-cert" # Required if 'external_certificates_offer_url' is set


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Given these PRs:
- https://github.com/canonical/observability-stack/pull/352
- https://github.com/canonical/observability-stack/pull/353
- https://github.com/canonical/observability-stack/pull/354

We have a consistent product story that the internal COS components: `ca` and `traefik` are conditional based on the state of the `internal_tls` and `ingress` variables respectively. We should mention this in the docs.

## Solution
<!-- A summary of the solution addressing the above issue -->
Update the docs.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
