### PR TITLE
fix: TF products failed to deploy due to SSC v2 pin

### DIFF
--- a/terraform/cos-lite/README.md
+++ b/terraform/cos-lite/README.md
@@ -19,7 +19,7 @@ This is a Terraform module facilitating the deployment of the COS Lite solution,
 | <a name="module_grafana"></a> [grafana](#module\_grafana) | git::https://github.com/canonical/grafana-k8s-operator//terraform | n/a |
 | <a name="module_loki"></a> [loki](#module\_loki) | git::https://github.com/canonical/loki-k8s-operator//terraform | n/a |
 | <a name="module_prometheus"></a> [prometheus](#module\_prometheus) | git::https://github.com/canonical/prometheus-k8s-operator//terraform | n/a |
-| <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | n/a |
+| <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | 0216698683a757a44d02e98c003a19aa7ffcfb63 |
 | <a name="module_traefik"></a> [traefik](#module\_traefik) | git::https://github.com/canonical/traefik-k8s-operator//terraform | n/a |
 
 ## Inputs

--- a/terraform/cos-lite/applications.tf
+++ b/terraform/cos-lite/applications.tf
@@ -65,7 +65,8 @@ module "prometheus" {
 }
 
 module "ssc" {
-  source = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
+  # The TF module bumped the Juju provider to v2 after this commit, pin for compatibility with provider v1 
+  source = "git::https://github.com/canonical/self-signed-certificates-operator//terraform?ref=0216698683a757a44d02e98c003a19aa7ffcfb63"
   count  = var.internal_tls ? 1 : 0
 
   app_name    = var.ssc.app_name

--- a/terraform/cos/README.md
+++ b/terraform/cos/README.md
@@ -23,7 +23,7 @@ This is a Terraform module facilitating the deployment of the COS solution, usin
 | <a name="module_loki"></a> [loki](#module\_loki) | git::https://github.com/canonical/loki-operators//terraform | n/a |
 | <a name="module_mimir"></a> [mimir](#module\_mimir) | git::https://github.com/canonical/mimir-operators//terraform | n/a |
 | <a name="module_opentelemetry_collector"></a> [opentelemetry\_collector](#module\_opentelemetry\_collector) | git::https://github.com/canonical/opentelemetry-collector-k8s-operator//terraform | n/a |
-| <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | n/a |
+| <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | 0216698683a757a44d02e98c003a19aa7ffcfb63 |
 | <a name="module_tempo"></a> [tempo](#module\_tempo) | git::https://github.com/canonical/tempo-operators//terraform | n/a |
 | <a name="module_traefik"></a> [traefik](#module\_traefik) | git::https://github.com/canonical/traefik-k8s-operator//terraform | n/a |
 

--- a/terraform/cos/applications.tf
+++ b/terraform/cos/applications.tf
@@ -120,7 +120,8 @@ module "opentelemetry_collector" {
 }
 
 module "ssc" {
-  source = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
+  # The TF module bumped the Juju provider to v2 after this commit, pin for compatibility with provider v1 
+  source = "git::https://github.com/canonical/self-signed-certificates-operator//terraform?ref=0216698683a757a44d02e98c003a19aa7ffcfb63"
   count  = var.internal_tls ? 1 : 0
 
   app_name    = var.ssc.app_name


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Workaround for this issue:
- https://github.com/canonical/self-signed-certificates-operator/issues/574

## Solution
<!-- A summary of the solution addressing the above issue -->
Pin to a commit hash prior to their limited support for Juju provider v2

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
