### PR TITLE
docs: Housekeeping

### DIFF
--- a/docs/how-to/deploy-and-manage/configure-granular-ingress.md
+++ b/docs/how-to/deploy-and-manage/configure-granular-ingress.md
@@ -6,10 +6,6 @@ myst:
 
 # How to configure granular ingress in COS
 
-```{Note}
-This feature is not available in track/2, only later versions have this ability
-```
-
 Both COS and COS Lite allow you to configure Traefik ingress for certain internal components. This configuration determines which applications are integrated with Traefik via an ingress interface; routing their traffic through Traefik.
 
 ```{mermaid}

--- a/docs/how-to/deploy-and-manage/install.md
+++ b/docs/how-to/deploy-and-manage/install.md
@@ -93,13 +93,11 @@ module "cos" {
 }
 ```
 
-### Revision pins
-Revision pinning is optional. With revision pins, subsequent `terraform apply` invocation will not refresh charms. Without revision pins, each `terraform apply` would refresh to the latest revision in track, if a new one released.
 where `.n` in `tf-cos-3.0.n` is the latest available patch version in the [COS tags](https://github.com/canonical/observability-stack/tags) list.
 
 ### Revision pins
 
-Deploying COS without revision pins, per component, will deploy the latest charms revisions in-track. Any subsequent Terraform plans will experience the same behaviour i.e., keeping COS up-to-date. However, if you require more stability, it is advised to pin the charm revisions of all components.
+Revision pinning is optional. With revision pins, subsequent `terraform apply` invocation will not refresh charms. Without revision pins, each `terraform apply` would refresh to the latest revision in track, if a new one released.
 
 ## Deploy COS Alerter
 

--- a/docs/how-to/deploy-and-manage/upgrade.md
+++ b/docs/how-to/deploy-and-manage/upgrade.md
@@ -8,13 +8,14 @@ myst:
 
 This guide shows how to upgrade an existing COS deployment to a newer track.
 
-## COS 3
-### Migrate from COS 2 to COS 3
+## COS 3.0
+### Migrate from COS 2 to COS 3.0
 Using Terraform:
 
 1. Update the channel input to track 2/stable and then:
     ```bash
-    terraform init -upgrade; terraform apply
+    terraform init -upgrade
+    terraform apply
     ```
 2. Manually refresh all charms to the latest revision in 2/stable 
     ```bash
@@ -22,7 +23,8 @@ Using Terraform:
     ```
 3. Update the Terraform module source ref to tf-cos-3.0.0 and then:
     ```bash
-    terraform init -upgrade; terraform apply
+    terraform init -upgrade
+    terraform apply
     ```
 4. Once Terraform has applied all resources, apply again until no new resources are applied:
     ```bash
@@ -34,7 +36,8 @@ Using Terraform:
 
 1. Update the channel input to track 2/stable and then:
     ```bash
-    terraform init -upgrade; terraform apply
+    terraform init -upgrade
+    terraform apply
     ```
 2. Manually refresh all charms to the latest revision in 2/stable 
     ```bash
@@ -42,7 +45,8 @@ Using Terraform:
     ```
 3. Update the Terraform module source ref to tf-cos-lite-3.0.0 and then:
     ```bash
-    terraform init -upgrade; terraform apply
+    terraform init -upgrade
+    terraform apply
     ```
 4. Once Terraform has applied all resources, apply again until no new resources are applied:
     ```bash

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,25 +1,25 @@
 ---
 myst:
  html_meta:
-  description: "Read COS 3 release notes to track new features, review requirements and compatibility, peripheral-charm changes, and breaking and deprecated changes."
+  description: "Read COS 3.0 release notes to track new features, review requirements and compatibility, peripheral-charm changes, and breaking and deprecated changes."
 ---
 
 # Release notes
 
-## COS 3
+## COS 3.0
 May 2026
 
-These release notes cover new features and changes in COS 3.
+These release notes cover new features and changes in COS 3.0.
 
-COS 3 newer versions of all underlying charms, as well as new features around charmed opentelemetry-collector.
+COS 3.0 newer versions of all underlying charms, as well as new features around charmed opentelemetry-collector.
 
-COS 3 is designated as a long-term support (LTS) release. This means it will continue to receive security updates and critical bug fixes for 15 years.
+COS 3.0 is designated as a long-term support (LTS) release. This means it will continue to receive security updates and critical bug fixes for 15 years.
 
 ```{note}
 COS track `3` is a release track for the COS bundle and does not correspond to any individual charm track on Charmhub. The individual charms retain their own versioning.
 ```
 
-If you have COS 2 installed, make plans to upgrade to COS 3 before July 2026.
+If you have COS 2 installed, make plans to upgrade to COS 3.0 before July 2026.
 
 See our [release policy](reference/release-policy) and [upgrade instructions](how-to/deploy-and-manage/upgrade).
 
@@ -28,10 +28,10 @@ To report bugs or security issues, refer to the index of [COS components](../ref
 ## Requirements and compatibility
 See [system requirements](reference/system-requirements).
 
-COS 3 is compatible with Juju v3.6+.
+COS 3.0 is compatible with Juju v3.6+.
 
 
-## What's new in COS 3
+## What's new in COS 3.0
 
 - **Opentelemetry collector**. Charmed opentelemetry-collector's workload is pinned to version 0.130 because the upstream `opentelemetry-collector-contrib` [project](https://github.com/open-telemetry/opentelemetry-collector-contrib) dropped support for Loki exporter in [release v0.131.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.131.0), stating that users can migrate to the OTLP exporters instead.
   - The logging integrations for the `opentelemetry-collector` charms rely on `lokiexporter` to send logs to Loki push API endpoints. Loki only recently received upstream support for an OTLP endpoint, and migrating to an OTLP-first ecosystem in COS began in 26.04. The objective is to have support for OTLP ecosystem-wide by the end of 26.10 and to deprecate the Loki Push API feature (`logging` endpoint). Support will then be fully dropped in 27.04, and the `opentelemetry-collector` charms will no longer be pinned to `v0.130`.
@@ -68,7 +68,7 @@ COS 3 is compatible with Juju v3.6+.
 ### Promtail is no longer maintained by Grafana Labs
 LogProxyConsumer is relying on promtail for scraping log lines from files, and sending them to Loki.
 Since March 2026, [promtail](https://grafana.com/docs/loki/latest/send-data/promtail/) is no longer under active development by Grafana Labs.
-Starting COS 3, it is recommended to use [pebble for forwarding logs](https://documentation.ubuntu.com/pebble/reference/log-forwarding/) from kubernetes workloads.
+Starting COS 3.0, it is recommended to use [pebble for forwarding logs](https://documentation.ubuntu.com/pebble/reference/log-forwarding/) from kubernetes workloads.
 You can use the `LogForwarder` object from the [`loki_push_api` charm library](https://charmhub.io/loki-k8s/libraries/loki_push_api)  to automatically set up pebble for log forwarding.
 
 Note that for this to work, the workload needs to emit logs to stdout (this is standard practice in kubernetes).


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
- We changed the way we name products `COS 2` -> `COS 3.0`
- `terraform init -upgrade; terraform apply` works, but it is better to split them because the `;` allows `apply` to run even if `init -upgrade` failed, which is not ideal.

## Solution
<!-- A summary of the solution addressing the above issue -->
- Update the naming to COS 3.0
- Split the terraform commands into 2
- Drive-by fix in the upgrade doc.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
