### PR TITLE
fix(docs): temporarily disable Charmhub link checks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,6 +242,7 @@ linkcheck_ignore = [
     r"https://.*\.sourceforge\.(net|io)/.*",
     "troubleshooting/",
     "https://github.com/canonical/observability-stack//terraform/cos-lite",
+    r"https://charmhub\.io/.*",
     ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,7 +242,9 @@ linkcheck_ignore = [
     r"https://.*\.sourceforge\.(net|io)/.*",
     "troubleshooting/",
     "https://github.com/canonical/observability-stack//terraform/cos-lite",
+    # Until https://github.com/canonical/observability-stack/issues/384 is closed
     r"https://charmhub\.io/.*",
+    r"https://ubuntu\.com/.*",
     ]
 
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Related to #384.

For example: [failed run](https://github.com/canonical/observability-stack/actions/runs/26961781288/job/79553743098)

## Solution
<!-- A summary of the solution addressing the above issue -->
Exclude those 2 hosts.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 

