### PR TITLE
feat: PGbouncer in COS

### DIFF
--- a/terraform/cos-lite/applications.tf
+++ b/terraform/cos-lite/applications.tf
@@ -55,6 +55,23 @@ module "loki" {
   units              = var.loki.units
 }
 
+resource "juju_application" "pgbouncer" {
+  name               = var.pgbouncer.app_name
+  config             = var.pgbouncer.config
+  constraints        = var.pgbouncer.constraints
+  model_uuid         = local.model_uuid
+  resources          = var.pgbouncer.resources
+  storage_directives = var.pgbouncer.storage_directives
+  trust              = true
+  units              = var.pgbouncer.units
+
+  charm {
+    name     = "pgbouncer-k8s"
+    channel  = local.channels.pgbouncer
+    revision = local.revisions.pgbouncer
+  }
+}
+
 module "prometheus" {
   source = "git::https://github.com/canonical/prometheus-k8s-operator//terraform"
 

--- a/terraform/cos-lite/integrations.tf
+++ b/terraform/cos-lite/integrations.tf
@@ -174,6 +174,10 @@ resource "juju_integration" "loki_logging" {
       app_name = module.prometheus.app_name
       endpoint = module.prometheus.requires.logging
     }
+    pgbouncer = {
+      app_name = juju_application.pgbouncer.name
+      endpoint = "logging"
+    }
   }
   model_uuid = local.model_uuid
 
@@ -342,6 +346,10 @@ resource "juju_integration" "internal_certificates" {
       app_name = module.loki.app_name
       endpoint = module.loki.requires.certificates
     }
+    pgbouncer = {
+      app_name = juju_application.pgbouncer.name
+      endpoint = "certificates"
+    }
     prometheus = {
       app_name = module.prometheus.app_name
       endpoint = module.prometheus.requires.certificates
@@ -412,5 +420,49 @@ resource "juju_integration" "external_prom_ca_cert" {
   application {
     name     = module.prometheus.app_name
     endpoint = module.prometheus.requires.receive_ca_cert
+  }
+}
+
+# -------------- # Provided by PGBouncer --------------
+
+resource "juju_integration" "pgbouncer_metrics" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "metrics-endpoint"
+  }
+
+  application {
+    name     = module.otel_collector.app_name
+    endpoint = module.otel_collector.endpoints.metrics_endpoint
+  }
+}
+
+resource "juju_integration" "pgbouncer_grafana_dashboards" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "grafana-dashboard"
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.grafana_dashboard
+  }
+}
+
+resource "juju_integration" "pgbouncer_grafana" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "database"
+  }
+
+  application {
+    name     = juju_application.grafana.name
+    endpoint = module.grafana.endpoints.database
   }
 }

--- a/terraform/cos-lite/locals.tf
+++ b/terraform/cos-lite/locals.tf
@@ -6,6 +6,7 @@ locals {
   reverse_proxy_enabled = anytrue(values(var.ingress))
   traefik_enabled       = local.reverse_proxy_enabled
   traefik_base          = "ubuntu@20.04"
+  grafana_ha            = var.grafana.units > 1
   tracks = {
     alertmanager = "dev"
     catalogue    = "dev"

--- a/terraform/cos-lite/variables.tf
+++ b/terraform/cos-lite/variables.tf
@@ -137,7 +137,7 @@ variable "grafana" {
     resources          = optional(map(string), {})
     revision           = optional(number, null)
     storage_directives = optional(map(string), {})
-    units              = optional(number, 1)
+    units              = optional(number, 3)
   })
   default     = {}
   description = "Application configuration for Grafana. For more details: https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application"

--- a/terraform/cos/integrations.tf
+++ b/terraform/cos/integrations.tf
@@ -536,3 +536,76 @@ resource "juju_integration" "traces_and_metrics_correlation" {
     endpoint = module.mimir.provides.send_datasource
   }
 }
+
+
+# -------------- # Provided by PGBouncer --------------
+
+resource "juju_integration" "otel_collector_pgbouncer_logging" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "logging"
+  }
+
+  application {
+    name     = module.otel_collector.app_name
+    endpoint = module.otel_collector.endpoints.receive_loki_logs
+  }
+}
+
+resource "juju_integration" "otel_collector_pgbouncer_metrics" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "metrics-endpoint"
+  }
+
+  application {
+    name     = module.otel_collector.app_name
+    endpoint = module.otel_collector.endpoints.metrics_endpoint
+  }
+}
+
+resource "juju_integration" "otel_collector_pgbouncer_tracing" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "tracing"
+  }
+
+  application {
+    name     = module.otel_collector.app_name
+    endpoint = module.otel_collector.endpoints.receive_traces
+  }
+}
+
+resource "juju_integration" "pgbouncer_grafana_dashboards" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "grafana-dashboard"
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.endpoints.grafana_dashboard
+  }
+}
+
+resource "juju_integration" "pgbouncer_grafana" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "database"
+  }
+
+  application {
+    name     = juju_application.grafana.name
+    endpoint = module.grafana.endpoints.database
+  }
+}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We want to bump the default unit count in Grafana to 3 units. To achieve this we need a few features:
1. Add [the pgsql integration](https://github.com/canonical/grafana-k8s-operator/blob/aba615f9ed00c64d0c18c06a64bb7170bb9a0e30/charmcraft.yaml#L62) to the Grafana TF module
2. Add an pgbouncer_grafana_offer_url input variable
3. Add validation that if unit >1 then offer_url is provided for Grafana
4. Deploy pgbouncer internally (conditionally)
5. We need to establish (conditionally) this database [integration between pgbouncer and grafana](https://github.com/canonical/comsys-cos-config/blob/266504a04d057aa836429e1bf9cef2377d8ce0cc/terraform/modules/core/main.tf#L110)

## Solution
<!-- A summary of the solution addressing the above issue -->


### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [ ] Added unit tests


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
