### PR TITLE
refactor: Consistent for_each integrations and state naming

### DIFF
--- a/terraform/cos-lite/integrations.tf
+++ b/terraform/cos-lite/integrations.tf
@@ -1,25 +1,81 @@
+# -------------- # Grafana Dashboard ---------------------
+
+resource "juju_integration" "grafana_dashboards" {
+  for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.provides.grafana_dashboard
+    }
+    prometheus = {
+      app_name = module.prometheus.app_name
+      endpoint = module.prometheus.provides.grafana_dashboard
+    }
+    loki = {
+      app_name = module.loki.app_name
+      endpoint = module.loki.provides.grafana_dashboard
+    }
+  }
+  model_uuid = local.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.requires.grafana_dashboard
+  }
+}
+
+# -------------- # Grafana Source Integrations --------------
+
+resource "juju_integration" "grafana_sources" {
+  for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.provides.grafana_source
+    }
+    prometheus = {
+      app_name = module.prometheus.app_name
+      endpoint = module.prometheus.provides.grafana_source
+    }
+    loki = {
+      app_name = module.loki.app_name
+      endpoint = module.loki.provides.grafana_source
+    }
+  }
+  model_uuid = local.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.requires.grafana_source
+  }
+}
+
 # -------------- # Provided by Alertmanager --------------
 
-resource "juju_integration" "alertmanager_grafana_dashboards" {
+resource "juju_integration" "alerting" {
+  for_each = {
+    prometheus = {
+      app_name = module.prometheus.app_name
+      endpoint = module.prometheus.requires.alertmanager
+    }
+    loki = {
+      app_name = module.loki.app_name
+      endpoint = module.loki.requires.alertmanager
+    }
+  }
   model_uuid = local.model_uuid
 
   application {
-    name     = module.alertmanager.app_name
-    endpoint = module.alertmanager.provides.grafana_dashboard
-  }
-
-  application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_dashboard
-  }
-}
-
-resource "juju_integration" "alertmanager_prometheus" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.prometheus.app_name
-    endpoint = module.prometheus.requires.alertmanager
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
   }
 
   application {
@@ -28,7 +84,23 @@ resource "juju_integration" "alertmanager_prometheus" {
   }
 }
 
-resource "juju_integration" "alertmanager_self_monitoring_prometheus" {
+# -------------- # Metrics Endpoint ----------------------
+
+resource "juju_integration" "metrics_endpoint" {
+  for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.provides.self_metrics_endpoint
+    }
+    grafana = {
+      app_name = module.grafana.app_name
+      endpoint = module.grafana.provides.metrics_endpoint
+    }
+    loki = {
+      app_name = module.loki.app_name
+      endpoint = module.loki.provides.metrics_endpoint
+    }
+  }
   model_uuid = local.model_uuid
 
   application {
@@ -37,42 +109,14 @@ resource "juju_integration" "alertmanager_self_monitoring_prometheus" {
   }
 
   application {
-    name     = module.alertmanager.app_name
-    endpoint = module.alertmanager.provides.self_metrics_endpoint
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
   }
 }
 
-resource "juju_integration" "alertmanager_loki" {
-  model_uuid = local.model_uuid
+resource "juju_integration" "traefik_self_monitoring_prometheus" {
+  count = local.traefik_enabled ? 1 : 0
 
-  application {
-    name     = module.loki.app_name
-    endpoint = module.loki.requires.alertmanager
-  }
-
-  application {
-    name     = module.alertmanager.app_name
-    endpoint = module.alertmanager.provides.alerting
-  }
-}
-
-resource "juju_integration" "grafana_source_alertmanager" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.alertmanager.app_name
-    endpoint = module.alertmanager.provides.grafana_source
-  }
-
-  application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_source
-  }
-}
-
-# -------------- # Provided by Grafana --------------
-
-resource "juju_integration" "grafana_self_monitoring_prometheus" {
   model_uuid = local.model_uuid
 
   application {
@@ -81,82 +125,8 @@ resource "juju_integration" "grafana_self_monitoring_prometheus" {
   }
 
   application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.provides.metrics_endpoint
-  }
-}
-
-# -------------- # Provided by Prometheus --------------
-
-resource "juju_integration" "prometheus_grafana_dashboards_provider" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.prometheus.app_name
-    endpoint = module.prometheus.provides.grafana_dashboard
-  }
-
-  application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_dashboard
-  }
-}
-
-resource "juju_integration" "prometheus_grafana_source" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.prometheus.app_name
-    endpoint = module.prometheus.provides.grafana_source
-  }
-
-  application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_source
-  }
-}
-
-# -------------- # Provided by Loki --------------
-
-resource "juju_integration" "loki_grafana_dashboards_provider" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.loki.app_name
-    endpoint = module.loki.provides.grafana_dashboard
-  }
-
-  application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_dashboard
-  }
-}
-
-resource "juju_integration" "loki_grafana_source" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.loki.app_name
-    endpoint = module.loki.provides.grafana_source
-  }
-
-  application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_source
-  }
-}
-
-resource "juju_integration" "loki_self_monitoring_prometheus" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.prometheus.app_name
-    endpoint = module.prometheus.requires.metrics_endpoint
-  }
-
-  application {
-    name     = module.loki.app_name
-    endpoint = module.loki.provides.metrics_endpoint
+    name     = module.traefik[0].app_name
+    endpoint = module.traefik[0].endpoints.metrics_endpoint
   }
 }
 
@@ -188,9 +158,19 @@ resource "juju_integration" "loki_logging" {
   }
 }
 
-# -------------- # Provided by Catalogue --------------
+# -------------- # Catalogue Integrations --------------
 
-resource "juju_integration" "catalogue_alertmanager" {
+resource "juju_integration" "catalogue_integrations" {
+  for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.requires.catalogue
+    }
+    prometheus = {
+      app_name = module.prometheus.app_name
+      endpoint = module.prometheus.requires.catalogue
+    }
+  }
   model_uuid = local.model_uuid
 
   application {
@@ -199,12 +179,12 @@ resource "juju_integration" "catalogue_alertmanager" {
   }
 
   application {
-    name     = module.alertmanager.app_name
-    endpoint = module.alertmanager.requires.catalogue
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
   }
 }
 
-resource "juju_integration" "catalogue_grafana" {
+resource "juju_integration" "catalogue_integration_grafana" {
   model_uuid = local.model_uuid
 
   application {
@@ -215,20 +195,6 @@ resource "juju_integration" "catalogue_grafana" {
   application {
     name     = module.grafana.app_name
     endpoint = module.grafana.requires.catalogue
-  }
-}
-
-resource "juju_integration" "catalogue_prometheus" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.catalogue.app_name
-    endpoint = module.catalogue.provides.catalogue
-  }
-
-  application {
-    name     = module.prometheus.app_name
-    endpoint = module.prometheus.requires.catalogue
   }
 }
 
@@ -303,22 +269,6 @@ resource "juju_integration" "ingress_per_unit" {
   application {
     name     = module.traefik[0].app_name
     endpoint = module.traefik[0].endpoints.ingress_per_unit
-  }
-}
-
-resource "juju_integration" "traefik_self_monitoring_prometheus" {
-  count = local.traefik_enabled ? 1 : 0
-
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.prometheus.app_name
-    endpoint = module.prometheus.requires.metrics_endpoint
-  }
-
-  application {
-    name     = module.traefik[0].app_name
-    endpoint = module.traefik[0].endpoints.metrics_endpoint
   }
 }
 

--- a/terraform/cos-lite/integrations.tf
+++ b/terraform/cos-lite/integrations.tf
@@ -1,4 +1,60 @@
-# -------------- # Grafana Dashboard ---------------------
+# -------------- # Alerting --------------
+
+resource "juju_integration" "alerting" {
+  for_each = {
+    prometheus = {
+      app_name = module.prometheus.app_name
+      endpoint = module.prometheus.requires.alertmanager
+    }
+    loki = {
+      app_name = module.loki.app_name
+      endpoint = module.loki.requires.alertmanager
+    }
+  }
+  model_uuid = local.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.alertmanager.app_name
+    endpoint = module.alertmanager.provides.alerting
+  }
+}
+
+# -------------- # Catalogue --------------
+
+resource "juju_integration" "catalogue_integrations" {
+  for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.requires.catalogue
+    }
+    grafana = {
+      app_name = module.grafana.app_name
+      endpoint = module.grafana.requires.catalogue
+    }
+    prometheus = {
+      app_name = module.prometheus.app_name
+      endpoint = module.prometheus.requires.catalogue
+    }
+  }
+  model_uuid = local.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.catalogue.app_name
+    endpoint = module.catalogue.provides.catalogue
+  }
+}
+
+# -------------- # Dashboards ---------------------
 
 resource "juju_integration" "grafana_dashboards" {
   for_each = {
@@ -28,7 +84,7 @@ resource "juju_integration" "grafana_dashboards" {
   }
 }
 
-# -------------- # Grafana Source Integrations --------------
+# -------------- # Grafana Source --------------
 
 resource "juju_integration" "grafana_sources" {
   for_each = {
@@ -58,77 +114,8 @@ resource "juju_integration" "grafana_sources" {
   }
 }
 
-# -------------- # Provided by Alertmanager --------------
+# -------------- # Logs ----------------------
 
-resource "juju_integration" "alerting" {
-  for_each = {
-    prometheus = {
-      app_name = module.prometheus.app_name
-      endpoint = module.prometheus.requires.alertmanager
-    }
-    loki = {
-      app_name = module.loki.app_name
-      endpoint = module.loki.requires.alertmanager
-    }
-  }
-  model_uuid = local.model_uuid
-
-  application {
-    name     = each.value.app_name
-    endpoint = each.value.endpoint
-  }
-
-  application {
-    name     = module.alertmanager.app_name
-    endpoint = module.alertmanager.provides.alerting
-  }
-}
-
-# -------------- # Metrics Endpoint ----------------------
-
-resource "juju_integration" "metrics_endpoint" {
-  for_each = {
-    alertmanager = {
-      app_name = module.alertmanager.app_name
-      endpoint = module.alertmanager.provides.self_metrics_endpoint
-    }
-    grafana = {
-      app_name = module.grafana.app_name
-      endpoint = module.grafana.provides.metrics_endpoint
-    }
-    loki = {
-      app_name = module.loki.app_name
-      endpoint = module.loki.provides.metrics_endpoint
-    }
-  }
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.prometheus.app_name
-    endpoint = module.prometheus.requires.metrics_endpoint
-  }
-
-  application {
-    name     = each.value.app_name
-    endpoint = each.value.endpoint
-  }
-}
-
-resource "juju_integration" "traefik_self_monitoring_prometheus" {
-  count = local.traefik_enabled ? 1 : 0
-
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.prometheus.app_name
-    endpoint = module.prometheus.requires.metrics_endpoint
-  }
-
-  application {
-    name     = module.traefik[0].app_name
-    endpoint = module.traefik[0].endpoints.metrics_endpoint
-  }
-}
 
 resource "juju_integration" "loki_logging" {
   for_each = {
@@ -158,47 +145,53 @@ resource "juju_integration" "loki_logging" {
   }
 }
 
-# -------------- # Catalogue Integrations --------------
+# -------------- # Metrics ----------------------
 
-resource "juju_integration" "catalogue_integrations" {
+resource "juju_integration" "metrics_endpoint" {
   for_each = {
     alertmanager = {
       app_name = module.alertmanager.app_name
-      endpoint = module.alertmanager.requires.catalogue
+      endpoint = module.alertmanager.provides.self_metrics_endpoint
     }
-    prometheus = {
-      app_name = module.prometheus.app_name
-      endpoint = module.prometheus.requires.catalogue
+    grafana = {
+      app_name = module.grafana.app_name
+      endpoint = module.grafana.provides.metrics_endpoint
+    }
+    loki = {
+      app_name = module.loki.app_name
+      endpoint = module.loki.provides.metrics_endpoint
     }
   }
   model_uuid = local.model_uuid
-
-  application {
-    name     = module.catalogue.app_name
-    endpoint = module.catalogue.provides.catalogue
-  }
 
   application {
     name     = each.value.app_name
     endpoint = each.value.endpoint
   }
+
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.requires.metrics_endpoint
+  }
 }
 
-resource "juju_integration" "catalogue_integration_grafana" {
+resource "juju_integration" "traefik_self_monitoring_prometheus" {
+  count = local.traefik_enabled ? 1 : 0
+
   model_uuid = local.model_uuid
 
   application {
-    name     = module.catalogue.app_name
-    endpoint = module.catalogue.provides.catalogue
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.requires.metrics_endpoint
   }
 
   application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.catalogue
+    name     = module.traefik[0].app_name
+    endpoint = module.traefik[0].endpoints.metrics_endpoint
   }
 }
 
-# -------------- # Provided by Traefik --------------
+# -------------- # Ingress --------------
 
 resource "juju_integration" "ingress" {
   for_each = {
@@ -272,7 +265,7 @@ resource "juju_integration" "ingress_per_unit" {
   }
 }
 
-# -------------- # Provided by Self-Signed-Certificates --------------
+# -------------- # Certificates --------------
 
 resource "juju_integration" "internal_certificates" {
   for_each = var.internal_tls ? {
@@ -301,13 +294,13 @@ resource "juju_integration" "internal_certificates" {
   model_uuid = local.model_uuid
 
   application {
-    name     = module.ssc[0].app_name
-    endpoint = module.ssc[0].provides.certificates
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
   }
 
   application {
-    name     = each.value.app_name
-    endpoint = each.value.endpoint
+    name     = module.ssc[0].app_name
+    endpoint = module.ssc[0].provides.certificates
   }
 }
 
@@ -327,8 +320,6 @@ resource "juju_integration" "traefik_receive_ca_certificate" {
   }
 }
 
-# -------------- # Provided by an external CA --------------
-
 resource "juju_integration" "external_traefik_certificates" {
   count = local.traefik_enabled && local.tls_termination ? 1 : 0
 
@@ -341,26 +332,23 @@ resource "juju_integration" "external_traefik_certificates" {
   }
 }
 
-resource "juju_integration" "external_grafana_ca_cert" {
-  count = local.tls_termination ? 1 : 0
+resource "juju_integration" "external_ca_cert" {
+  for_each = local.tls_termination ? {
+    grafana = {
+      app_name = module.grafana.app_name
+      endpoint = module.grafana.requires.receive_ca_cert
+    }
+    prometheus = {
+      app_name = module.prometheus.app_name
+      endpoint = module.prometheus.requires.receive_ca_cert
+    }
+  } : {}
 
   model_uuid = local.model_uuid
 
   application { offer_url = var.external_ca_cert_offer_url }
   application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.receive_ca_cert
-  }
-}
-
-resource "juju_integration" "external_prom_ca_cert" {
-  count = local.tls_termination ? 1 : 0
-
-  model_uuid = local.model_uuid
-
-  application { offer_url = var.external_ca_cert_offer_url }
-  application {
-    name     = module.prometheus.app_name
-    endpoint = module.prometheus.requires.receive_ca_cert
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
   }
 }

--- a/terraform/cos-lite/upgrades.tf
+++ b/terraform/cos-lite/upgrades.tf
@@ -64,8 +64,79 @@ data "juju_charm" "traefik_info" {
 
 # -------------- # State migrations -------------- #
 
-# refactor(cos-lite): Traefik and SSC are conditional (#353)
+# refactor: Traefik and SSC are conditional (#353)
 moved {
   from = module.traefik
   to   = module.traefik[0]
+}
+
+# refactor: collapse per-app integrations into for_each loops
+moved {
+  from = juju_integration.alertmanager_grafana_dashboards
+  to   = juju_integration.grafana_dashboards["alertmanager"]
+}
+
+moved {
+  from = juju_integration.prometheus_grafana_dashboards_provider
+  to   = juju_integration.grafana_dashboards["prometheus"]
+}
+
+moved {
+  from = juju_integration.loki_grafana_dashboards_provider
+  to   = juju_integration.grafana_dashboards["loki"]
+}
+
+moved {
+  from = juju_integration.grafana_source_alertmanager
+  to   = juju_integration.grafana_sources["alertmanager"]
+}
+
+moved {
+  from = juju_integration.prometheus_grafana_source
+  to   = juju_integration.grafana_sources["prometheus"]
+}
+
+moved {
+  from = juju_integration.loki_grafana_source
+  to   = juju_integration.grafana_sources["loki"]
+}
+
+moved {
+  from = juju_integration.alertmanager_prometheus
+  to   = juju_integration.alerting["prometheus"]
+}
+
+moved {
+  from = juju_integration.alertmanager_loki
+  to   = juju_integration.alerting["loki"]
+}
+
+moved {
+  from = juju_integration.alertmanager_self_monitoring_prometheus
+  to   = juju_integration.metrics_endpoint["alertmanager"]
+}
+
+moved {
+  from = juju_integration.grafana_self_monitoring_prometheus
+  to   = juju_integration.metrics_endpoint["grafana"]
+}
+
+moved {
+  from = juju_integration.loki_self_monitoring_prometheus
+  to   = juju_integration.metrics_endpoint["loki"]
+}
+
+moved {
+  from = juju_integration.catalogue_alertmanager
+  to   = juju_integration.catalogue_integrations["alertmanager"]
+}
+
+moved {
+  from = juju_integration.catalogue_prometheus
+  to   = juju_integration.catalogue_integrations["prometheus"]
+}
+
+moved {
+  from = juju_integration.catalogue_grafana
+  to   = juju_integration.catalogue_integration_grafana
 }

--- a/terraform/cos-lite/upgrades.tf
+++ b/terraform/cos-lite/upgrades.tf
@@ -138,5 +138,15 @@ moved {
 
 moved {
   from = juju_integration.catalogue_grafana
-  to   = juju_integration.catalogue_integration_grafana
+  to   = juju_integration.catalogue_integrations["grafana"]
+}
+
+moved {
+  from = juju_integration.external_grafana_ca_cert[0]
+  to   = juju_integration.external_ca_cert["grafana"]
+}
+
+moved {
+  from = juju_integration.external_prom_ca_cert[0]
+  to   = juju_integration.external_ca_cert["prometheus"]
 }

--- a/terraform/cos-lite/upgrades.tf
+++ b/terraform/cos-lite/upgrades.tf
@@ -150,3 +150,50 @@ moved {
   from = juju_integration.external_prom_ca_cert[0]
   to   = juju_integration.external_ca_cert["prometheus"]
 }
+
+# refactor: move integrations after for_each loop implementation
+moved {
+  from = juju_integration.alertmanager_certificates[0]
+  to   = juju_integration.internal_certificates["alertmanager"]
+}
+
+moved {
+  from = juju_integration.catalogue_certificates[0]
+  to   = juju_integration.internal_certificates["catalogue"]
+}
+
+moved {
+  from = juju_integration.grafana_certificates[0]
+  to   = juju_integration.internal_certificates["grafana"]
+}
+
+moved {
+  from = juju_integration.loki_certificates[0]
+  to   = juju_integration.internal_certificates["loki"]
+}
+
+moved {
+  from = juju_integration.prometheus_certificates[0]
+  to   = juju_integration.internal_certificates["prometheus"]
+}
+
+# refactor: collapse per-app ingress into the ingress/ingress_per_unit for_each loops
+moved {
+  from = juju_integration.alertmanager_ingress
+  to   = juju_integration.ingress["alertmanager"]
+}
+
+moved {
+  from = juju_integration.catalogue_ingress
+  to   = juju_integration.ingress["catalogue"]
+}
+
+moved {
+  from = juju_integration.loki_ingress
+  to   = juju_integration.ingress_per_unit["loki"]
+}
+
+moved {
+  from = juju_integration.prometheus_ingress
+  to   = juju_integration.ingress_per_unit["prometheus"]
+}

--- a/terraform/cos/integrations.tf
+++ b/terraform/cos/integrations.tf
@@ -83,7 +83,7 @@ resource "juju_integration" "charm_tracing_grafana" {
 
 # -------------- # Metrics Endpoint ----------------------
 
-resource "juju_integration" "otelcol_metrics_endpoint" {
+resource "juju_integration" "metrics_endpoint" {
   for_each = {
     alertmanager = {
       app_name = module.alertmanager.app_name

--- a/terraform/cos/integrations.tf
+++ b/terraform/cos/integrations.tf
@@ -1,196 +1,4 @@
-# -------------- # Grafana Dashboard ---------------------
-
-resource "juju_integration" "grafana_dashboards" {
-  for_each = {
-    alertmanager = {
-      app_name = module.alertmanager.app_name
-      endpoint = module.alertmanager.provides.grafana_dashboard
-    }
-    mimir = {
-      app_name = module.mimir.app_names.mimir_coordinator
-      endpoint = module.mimir.provides.grafana_dashboards_provider
-    }
-    loki = {
-      app_name = module.loki.app_names.loki_coordinator
-      endpoint = module.loki.provides.grafana_dashboards_provider
-    }
-    otelcol = {
-      app_name = module.opentelemetry_collector.app_name
-      endpoint = module.opentelemetry_collector.provides.grafana_dashboards_provider
-    }
-    tempo = {
-      app_name = module.tempo.app_names.tempo_coordinator
-      endpoint = module.tempo.provides.grafana_dashboard
-    }
-  }
-
-  model_uuid = local.model_uuid
-
-  application {
-    name     = each.value.app_name
-    endpoint = each.value.endpoint
-  }
-
-  application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_dashboard
-  }
-
-  lifecycle { replace_triggered_by = [terraform_data.grafana_litestream_resource] }
-}
-
-# -------------- # Charm Tracing ------------------------
-
-resource "juju_integration" "charm_tracing" {
-  for_each = {
-    mimir = {
-      app_name = module.mimir.app_names.mimir_coordinator
-      endpoint = module.mimir.requires.charm_tracing
-    }
-    loki = {
-      app_name = module.loki.app_names.loki_coordinator
-      endpoint = module.loki.requires.charm_tracing
-    }
-  }
-  model_uuid = local.model_uuid
-
-  application {
-    name     = each.value.app_name
-    endpoint = each.value.endpoint
-  }
-
-  application {
-    name     = module.opentelemetry_collector.app_name
-    endpoint = module.opentelemetry_collector.provides.receive_traces
-  }
-}
-
-resource "juju_integration" "charm_tracing_grafana" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.charm_tracing
-  }
-
-  application {
-    name     = module.opentelemetry_collector.app_name
-    endpoint = module.opentelemetry_collector.provides.receive_traces
-  }
-
-  lifecycle { replace_triggered_by = [terraform_data.grafana_litestream_resource] }
-}
-
-# -------------- # Metrics Endpoint ----------------------
-
-resource "juju_integration" "metrics_endpoint" {
-  for_each = {
-    alertmanager = {
-      app_name = module.alertmanager.app_name
-      endpoint = module.alertmanager.provides.self_metrics_endpoint
-    }
-    mimir = {
-      app_name = module.mimir.app_names.mimir_coordinator
-      endpoint = module.mimir.provides.self_metrics_endpoint
-    }
-    loki = {
-      app_name = module.loki.app_names.loki_coordinator
-      endpoint = module.loki.provides.self_metrics_endpoint
-    }
-    tempo = {
-      app_name = module.tempo.app_names.tempo_coordinator
-      endpoint = module.tempo.provides.metrics_endpoint
-    }
-  }
-  model_uuid = local.model_uuid
-
-  application {
-    name     = each.value.app_name
-    endpoint = each.value.endpoint
-  }
-
-  application {
-    name     = module.opentelemetry_collector.app_name
-    endpoint = module.opentelemetry_collector.requires.metrics_endpoint
-  }
-}
-
-# -------------- # Grafana Source Integrations --------------
-
-resource "juju_integration" "grafana_sources" {
-  for_each = {
-    alertmanager = {
-      app_name = module.alertmanager.app_name
-      endpoint = module.alertmanager.provides.grafana_source
-    }
-    mimir = {
-      app_name = module.mimir.app_names.mimir_coordinator
-      endpoint = module.mimir.provides.grafana_source
-    }
-    loki = {
-      app_name = module.loki.app_names.loki_coordinator
-      endpoint = module.loki.provides.grafana_source
-    }
-    tempo = {
-      app_name = module.tempo.app_names.tempo_coordinator
-      endpoint = module.tempo.provides.grafana_source
-    }
-  }
-
-  model_uuid = local.model_uuid
-
-  application {
-    name     = each.value.app_name
-    endpoint = each.value.endpoint
-  }
-
-  application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_source
-  }
-
-  lifecycle { replace_triggered_by = [terraform_data.grafana_litestream_resource] }
-}
-
-# -------------- # Receive Loki Logs ---------------------
-
-resource "juju_integration" "otelcol_logging_provider" {
-  for_each = {
-    alertmanager = {
-      app_name = module.alertmanager.app_name
-      endpoint = module.alertmanager.requires.logging
-    }
-    grafana = {
-      app_name = module.grafana.app_name
-      endpoint = module.grafana.requires.logging
-    }
-    mimir = {
-      app_name = module.mimir.app_names.mimir_coordinator
-      endpoint = module.mimir.requires.logging_consumer
-    }
-    loki = {
-      app_name = module.loki.app_names.loki_coordinator
-      endpoint = module.loki.requires.logging_consumer
-    }
-    tempo = {
-      app_name = module.tempo.app_names.tempo_coordinator
-      endpoint = module.tempo.requires.logging
-    }
-  }
-  model_uuid = local.model_uuid
-
-  application {
-    name     = each.value.app_name
-    endpoint = each.value.endpoint
-  }
-
-  application {
-    name     = module.opentelemetry_collector.app_name
-    endpoint = module.opentelemetry_collector.provides.receive_loki_logs
-  }
-}
-
-# -------- Provided by Alertmanager --------------
+# -------------- # Alerting --------------
 
 resource "juju_integration" "alerting" {
   for_each = {
@@ -216,55 +24,7 @@ resource "juju_integration" "alerting" {
   }
 }
 
-
-# -------------- # Provided by Loki --------------
-
-resource "juju_integration" "loki_logging_otelcol_logging_consumer" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.loki.app_names.loki_coordinator
-    endpoint = module.loki.provides.logging
-  }
-
-  application {
-    name     = module.opentelemetry_collector.app_name
-    endpoint = module.opentelemetry_collector.requires.send_loki_logs
-  }
-}
-
-
-# -------------- # Provided by Tempo --------------
-
-resource "juju_integration" "tempo_tracing_otelcol_tracing" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.tempo.app_names.tempo_coordinator
-    endpoint = module.tempo.provides.tracing
-  }
-
-  application {
-    name     = module.opentelemetry_collector.app_name
-    endpoint = module.opentelemetry_collector.requires.send_traces
-  }
-}
-
-resource "juju_integration" "tempo_send_remote_write_mimir_receive_remote_write" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.tempo.app_names.tempo_coordinator
-    endpoint = module.tempo.requires.send-remote-write
-  }
-
-  application {
-    name     = module.mimir.app_names.mimir_coordinator
-    endpoint = module.mimir.provides.receive_remote_write
-  }
-}
-
-# -------------- # Catalogue Integrations --------------
+# -------------- # Catalogue --------------
 
 resource "juju_integration" "catalogue_integrations" {
   for_each = {
@@ -309,6 +69,276 @@ resource "juju_integration" "catalogue_integration_grafana" {
   }
 
   lifecycle { replace_triggered_by = [terraform_data.grafana_litestream_resource] }
+}
+
+# -------------- # Dashboards ---------------------
+
+resource "juju_integration" "grafana_dashboards" {
+  for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.provides.grafana_dashboard
+    }
+    mimir = {
+      app_name = module.mimir.app_names.mimir_coordinator
+      endpoint = module.mimir.provides.grafana_dashboards_provider
+    }
+    loki = {
+      app_name = module.loki.app_names.loki_coordinator
+      endpoint = module.loki.provides.grafana_dashboards_provider
+    }
+    otelcol = {
+      app_name = module.opentelemetry_collector.app_name
+      endpoint = module.opentelemetry_collector.provides.grafana_dashboards_provider
+    }
+    tempo = {
+      app_name = module.tempo.app_names.tempo_coordinator
+      endpoint = module.tempo.provides.grafana_dashboard
+    }
+  }
+
+  model_uuid = local.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.requires.grafana_dashboard
+  }
+
+  lifecycle { replace_triggered_by = [terraform_data.grafana_litestream_resource] }
+}
+
+# -------------- # Grafana Source --------------
+
+resource "juju_integration" "grafana_sources" {
+  for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.provides.grafana_source
+    }
+    mimir = {
+      app_name = module.mimir.app_names.mimir_coordinator
+      endpoint = module.mimir.provides.grafana_source
+    }
+    loki = {
+      app_name = module.loki.app_names.loki_coordinator
+      endpoint = module.loki.provides.grafana_source
+    }
+    tempo = {
+      app_name = module.tempo.app_names.tempo_coordinator
+      endpoint = module.tempo.provides.grafana_source
+    }
+  }
+
+  model_uuid = local.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.requires.grafana_source
+  }
+
+  lifecycle { replace_triggered_by = [terraform_data.grafana_litestream_resource] }
+}
+
+# -------------- # Logs ---------------------
+
+resource "juju_integration" "otelcol_logging_provider" {
+  for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.requires.logging
+    }
+    grafana = {
+      app_name = module.grafana.app_name
+      endpoint = module.grafana.requires.logging
+    }
+    mimir = {
+      app_name = module.mimir.app_names.mimir_coordinator
+      endpoint = module.mimir.requires.logging_consumer
+    }
+    loki = {
+      app_name = module.loki.app_names.loki_coordinator
+      endpoint = module.loki.requires.logging_consumer
+    }
+    tempo = {
+      app_name = module.tempo.app_names.tempo_coordinator
+      endpoint = module.tempo.requires.logging
+    }
+  }
+  model_uuid = local.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.opentelemetry_collector.app_name
+    endpoint = module.opentelemetry_collector.provides.receive_loki_logs
+  }
+}
+
+resource "juju_integration" "loki_logging_otelcol_logging_consumer" {
+  model_uuid = local.model_uuid
+
+  application {
+    name     = module.loki.app_names.loki_coordinator
+    endpoint = module.loki.provides.logging
+  }
+
+  application {
+    name     = module.opentelemetry_collector.app_name
+    endpoint = module.opentelemetry_collector.requires.send_loki_logs
+  }
+}
+
+# -------------- # Metrics ----------------------
+
+resource "juju_integration" "metrics_endpoint" {
+  for_each = {
+    alertmanager = {
+      app_name = module.alertmanager.app_name
+      endpoint = module.alertmanager.provides.self_metrics_endpoint
+    }
+    mimir = {
+      app_name = module.mimir.app_names.mimir_coordinator
+      endpoint = module.mimir.provides.self_metrics_endpoint
+    }
+    loki = {
+      app_name = module.loki.app_names.loki_coordinator
+      endpoint = module.loki.provides.self_metrics_endpoint
+    }
+    tempo = {
+      app_name = module.tempo.app_names.tempo_coordinator
+      endpoint = module.tempo.provides.metrics_endpoint
+    }
+  }
+  model_uuid = local.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.opentelemetry_collector.app_name
+    endpoint = module.opentelemetry_collector.requires.metrics_endpoint
+  }
+}
+
+resource "juju_integration" "receive_remote_write" {
+  for_each = {
+    opentelemetry_collector = {
+      app_name = module.opentelemetry_collector.app_name
+      endpoint = module.opentelemetry_collector.requires.send_remote_write
+    }
+    tempo = {
+      app_name = module.tempo.app_names.tempo_coordinator
+      endpoint = module.tempo.requires.send-remote-write
+    }
+  }
+  model_uuid = local.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.mimir.app_names.mimir_coordinator
+    endpoint = module.mimir.provides.receive_remote_write
+  }
+}
+
+# -------------- # Tracing ------------------------
+
+resource "juju_integration" "charm_tracing" {
+  for_each = {
+    mimir = {
+      app_name = module.mimir.app_names.mimir_coordinator
+      endpoint = module.mimir.requires.charm_tracing
+    }
+    loki = {
+      app_name = module.loki.app_names.loki_coordinator
+      endpoint = module.loki.requires.charm_tracing
+    }
+  }
+  model_uuid = local.model_uuid
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
+
+  application {
+    name     = module.opentelemetry_collector.app_name
+    endpoint = module.opentelemetry_collector.provides.receive_traces
+  }
+}
+
+resource "juju_integration" "charm_tracing_grafana" {
+  model_uuid = local.model_uuid
+
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.requires.charm_tracing
+  }
+
+  application {
+    name     = module.opentelemetry_collector.app_name
+    endpoint = module.opentelemetry_collector.provides.receive_traces
+  }
+
+  lifecycle { replace_triggered_by = [terraform_data.grafana_litestream_resource] }
+}
+
+resource "juju_integration" "tempo_tracing_otelcol_tracing" {
+  model_uuid = local.model_uuid
+
+  application {
+    name     = module.tempo.app_names.tempo_coordinator
+    endpoint = module.tempo.provides.tracing
+  }
+
+  application {
+    name     = module.opentelemetry_collector.app_name
+    endpoint = module.opentelemetry_collector.requires.send_traces
+  }
+}
+
+# -------------- # Telemetry Correlations ---------------------
+
+resource "juju_integration" "receive_datasource" {
+  for_each = {
+    loki = {
+      app_name = module.loki.app_names.loki_coordinator
+      endpoint = module.loki.provides.send_datasource
+    }
+    mimir = {
+      app_name = module.mimir.app_names.mimir_coordinator
+      endpoint = module.mimir.provides.send_datasource
+    }
+  }
+  model_uuid = local.model_uuid
+
+  application {
+    name     = module.tempo.app_names.tempo_coordinator
+    endpoint = module.tempo.requires.receive_datasource
+  }
+
+  application {
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
+  }
 }
 
 # -------------- # Ingress --------------------------
@@ -391,23 +421,8 @@ resource "juju_integration" "traefik_route" {
   }
 }
 
-# -------------- # Provided by OpenTelemetry Collector --------------
+# -------------- # Certificates --------------
 
-resource "juju_integration" "opentelemetry_collector_mimir_metrics" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.mimir.app_names.mimir_coordinator
-    endpoint = module.mimir.provides.receive_remote_write
-  }
-
-  application {
-    name     = module.opentelemetry_collector.app_name
-    endpoint = module.opentelemetry_collector.requires.send_remote_write
-  }
-}
-
-# -------------- # Certificate Integrations --------------
 resource "juju_integration" "internal_certificates" {
   for_each = var.internal_tls ? {
     alertmanager = {
@@ -469,8 +484,6 @@ resource "juju_integration" "traefik_receive_ca_certificate" {
   }
 }
 
-# -------------- # Provided by an external CA --------------
-
 resource "juju_integration" "external_traefik_certificates" {
   count = local.traefik_enabled && local.tls_termination ? 1 : 0
 
@@ -483,56 +496,23 @@ resource "juju_integration" "external_traefik_certificates" {
   }
 }
 
-resource "juju_integration" "external_grafana_ca_cert" {
-  count = local.tls_termination ? 1 : 0
+resource "juju_integration" "external_ca_cert" {
+  for_each = local.tls_termination ? {
+    grafana = {
+      app_name = module.grafana.app_name
+      endpoint = module.grafana.requires.receive_ca_cert
+    }
+    opentelemetry_collector = {
+      app_name = module.opentelemetry_collector.app_name
+      endpoint = module.opentelemetry_collector.requires.receive_ca_cert
+    }
+  } : {}
 
   model_uuid = local.model_uuid
 
   application { offer_url = var.external_ca_cert_offer_url }
   application {
-    name     = module.grafana.app_name
-    endpoint = module.grafana.requires.receive_ca_cert
-  }
-}
-
-resource "juju_integration" "external_otelcol_ca_cert" {
-  count = local.tls_termination ? 1 : 0
-
-  model_uuid = local.model_uuid
-
-  application { offer_url = var.external_ca_cert_offer_url }
-  application {
-    name     = module.opentelemetry_collector.app_name
-    endpoint = module.opentelemetry_collector.requires.receive_ca_cert
-  }
-}
-
-# -------------- # Telemetry correlations ---------------------
-
-resource "juju_integration" "traces_and_logs_correlation" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.tempo.app_names.tempo_coordinator
-    endpoint = module.tempo.requires.receive_datasource
-  }
-
-  application {
-    name     = module.loki.app_names.loki_coordinator
-    endpoint = module.loki.provides.send_datasource
-  }
-}
-
-resource "juju_integration" "traces_and_metrics_correlation" {
-  model_uuid = local.model_uuid
-
-  application {
-    name     = module.tempo.app_names.tempo_coordinator
-    endpoint = module.tempo.requires.receive_datasource
-  }
-
-  application {
-    name     = module.mimir.app_names.mimir_coordinator
-    endpoint = module.mimir.provides.send_datasource
+    name     = each.value.app_name
+    endpoint = each.value.endpoint
   }
 }

--- a/terraform/cos/upgrades.tf
+++ b/terraform/cos/upgrades.tf
@@ -111,3 +111,36 @@ moved {
   from = juju_integration.otelcol_metrics_endpoint
   to   = juju_integration.metrics_endpoint
 }
+
+# refactor: collapse mimir receive-remote-write integrations into a for_each loop
+moved {
+  from = juju_integration.opentelemetry_collector_mimir_metrics
+  to   = juju_integration.receive_remote_write["opentelemetry_collector"]
+}
+
+moved {
+  from = juju_integration.tempo_send_remote_write_mimir_receive_remote_write
+  to   = juju_integration.receive_remote_write["tempo"]
+}
+
+# refactor: collapse datasource-exchange correlations into a for_each loop
+moved {
+  from = juju_integration.traces_and_logs_correlation
+  to   = juju_integration.receive_datasource["loki"]
+}
+
+moved {
+  from = juju_integration.traces_and_metrics_correlation
+  to   = juju_integration.receive_datasource["mimir"]
+}
+
+# refactor: collapse external CA-cert integrations into a for_each loop
+moved {
+  from = juju_integration.external_grafana_ca_cert[0]
+  to   = juju_integration.external_ca_cert["grafana"]
+}
+
+moved {
+  from = juju_integration.external_otelcol_ca_cert[0]
+  to   = juju_integration.external_ca_cert["opentelemetry_collector"]
+}

--- a/terraform/cos/upgrades.tf
+++ b/terraform/cos/upgrades.tf
@@ -112,7 +112,7 @@ moved {
   to   = juju_integration.metrics_endpoint
 }
 
-# refactor: collapse mimir receive-remote-write integrations into a for_each loop
+# refactor: move integrations after for_each loop implementation
 moved {
   from = juju_integration.opentelemetry_collector_mimir_metrics
   to   = juju_integration.receive_remote_write["opentelemetry_collector"]
@@ -123,7 +123,6 @@ moved {
   to   = juju_integration.receive_remote_write["tempo"]
 }
 
-# refactor: collapse datasource-exchange correlations into a for_each loop
 moved {
   from = juju_integration.traces_and_logs_correlation
   to   = juju_integration.receive_datasource["loki"]
@@ -134,7 +133,6 @@ moved {
   to   = juju_integration.receive_datasource["mimir"]
 }
 
-# refactor: collapse external CA-cert integrations into a for_each loop
 moved {
   from = juju_integration.external_grafana_ca_cert[0]
   to   = juju_integration.external_ca_cert["grafana"]
@@ -143,4 +141,14 @@ moved {
 moved {
   from = juju_integration.external_otelcol_ca_cert[0]
   to   = juju_integration.external_ca_cert["opentelemetry_collector"]
+}
+
+moved {
+  from = juju_integration.catalogue_integrations["grafana"]
+  to   = juju_integration.catalogue_integration_grafana
+}
+
+moved {
+  from = juju_integration.charm_tracing["grafana"]
+  to   = juju_integration.charm_tracing_grafana
 }

--- a/terraform/cos/upgrades.tf
+++ b/terraform/cos/upgrades.tf
@@ -100,8 +100,14 @@ data "juju_charm" "traefik_info" {
 
 # -------------- # State migrations -------------- #
 
-# refactor(cos): Traefik and SSC are conditional (#354)
+# refactor: Traefik and SSC are conditional (#354)
 moved {
   from = module.traefik
   to   = module.traefik[0]
+}
+
+# refactor: align metrics-endpoint loop name with cos-lite
+moved {
+  from = juju_integration.otelcol_metrics_endpoint
+  to   = juju_integration.metrics_endpoint
 }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

The two modules had grown a large number of near-identical `juju_integration` blocks (one per application for dashboards, datasources, alerting, metrics, catalogue, CA certs, etc.). This made the modules verbose, hard to scan, and easy to drift apart from each other. Collapsing them into `for_each` loops keyed by application:

- Reduces boilerplate and the surface area for copy-paste errors.
- Gives `cos` and `cos-lite` a parallel, predictable state layout.
- Names resources after the relation/endpoint (e.g. `metrics_endpoint`, `receive_remote_write`, `grafana_dashboards`) rather than implementation-specific app-pair names.


## Solution
<!-- A summary of the solution addressing the above issue -->

Consolidates repetitive per-application `juju_integration` resources in the `cos` and `cos-lite` Terraform modules into `for_each` loops, and aligns the state/resource naming between the two modules so they share a consistent design. Each consolidation is paired with a `moved` block so existing deployments migrate in-place — **no integration is destroyed or recreated**.

### Changes

**`cos-lite`**
- Consolidated into `for_each` loops: `grafana_dashboards`, `grafana_sources`, `alerting`, `metrics_endpoint`, `catalogue_integrations` (now includes grafana), and `external_ca_cert`.
- Kept standalone where genuinely unique: `traefik_self_monitoring_prometheus`, `grafana_ingress`, `traefik_receive_ca_certificate`, `external_traefik_certificates`, `ingress`, `ingress_per_unit`, `internal_certificates`.

**`cos`**
- Renamed `otelcol_metrics_endpoint` → `metrics_endpoint`.
- Combined remote-write relations into `receive_remote_write` (keys: `opentelemetry_collector`, `tempo`).
- Combined Tempo correlations into `receive_datasource` (keys: `loki`, `mimir`).
- Combined external CA relations into `external_ca_cert` (keys: `grafana`, `opentelemetry_collector`).
- Grafana relations that require the Litestream replace-trigger (`catalogue_integration_grafana`, `charm_tracing_grafana`) are intentionally left split — folding them into loops would drop the `replace_triggered_by` lifecycle.

**State migrations (`upgrades.tf`)**
- Added `moved` blocks for every renamed/consolidated resource so live relations migrate without churn. `count`-based sources correctly migrate from their `[0]` instance address to the new keyed address.

### Naming convention

Integration resources are now named after the relation/endpoint and use the same keys across both modules (e.g. `metrics_endpoint`, `grafana_dashboards`, `grafana_sources`, `alerting`, `catalogue_integrations`, `external_ca_cert`), giving the two modules a matching state design.


### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Adding more `moved` blocks will speed up the cross-track upgrades.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- Regression audit confirms every integration present on `main` still exists, every removed/renamed resource has exactly one corresponding `moved` block, no orphan `moved` blocks remain, and all `for_each` keys referenced by `moved` blocks resolve.


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
- This is a **state-only reorganization**. Existing deployments pick up the new addresses via `moved` blocks on the next `terraform apply` — `plan` should show only moves, no creates/destroys of integrations.
- The `moved` blocks are introduced in the COS 3.0 and are safe to remove in COS 4.0
- `cos-dev` is intentionally untouched.
