### PR TITLE
fix!: Terraform Juju provider pin

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,7 +11,7 @@ May 2026
 
 These release notes cover new features and changes in COS 3.0.
 
-COS 3.0 newer versions of all underlying charms, as well as new features around charmed opentelemetry-collector.
+COS 3.0 features newer versions of all underlying charms, as well as new features around charmed opentelemetry-collector.
 
 COS 3.0 is designated as a long-term support (LTS) release. This means it will continue to receive security updates and critical bug fixes for 15 years.
 

--- a/terraform/cos-lite/README.md
+++ b/terraform/cos-lite/README.md
@@ -70,7 +70,7 @@ If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module
 
 ```hcl
 module "cos" {
-  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=75f5e0bedde913a3f1c918be44716db8ef2c69a1"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=37b62b863e1f288d760232bab634f41b8597d6bf"
 }
 ```
 

--- a/terraform/cos-lite/README.md
+++ b/terraform/cos-lite/README.md
@@ -67,7 +67,7 @@ module "cos-lite" {
 Otherwise, you can deploy from main (without `?ref`) which supports the v1 Terraform Juju provider. See the [v1 migration documentation](https://documentation.ubuntu.com/terraform-provider-juju/v1/howto/manage-provider/upgrade-provider-to-v1/) if you need to upgrade your modules.
 
 #### Provider >= 1.0.0, < 1.4.0
-If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the [37b62b8](https://github.com/canonical/observability-stack/commit/37b62b863e1f288d760232bab634f41b8597d6bf) commit hash:
+If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the [c1c8bd9](https://github.com/canonical/observability-stack/commit/c1c8bd9a17abe079242eb9535c6b7a4fa8832a02) commit hash:
 
 ```hcl
 module "cos-lite" {

--- a/terraform/cos-lite/README.md
+++ b/terraform/cos-lite/README.md
@@ -7,7 +7,7 @@ This is a Terraform module facilitating the deployment of the COS Lite solution,
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.4.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -52,6 +52,30 @@ This is a Terraform module facilitating the deployment of the COS Lite solution,
 
 ## Usage
 
+### Using different Terraform Juju provider versions
+
+#### Provider v0
+If you require the Terraform Juju provider `< 1.0.0`, then deploy the COS module with the `tf-provider-v0` tag:
+
+```hcl
+module "cos" {
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=tf-provider-v0"
+}
+```
+
+Otherwise, you can deploy from main (without `?ref`) which supports the v1 Terraform Juju provider. See the [v1 migration documentation](https://documentation.ubuntu.com/terraform-provider-juju/v1/howto/manage-provider/upgrade-provider-to-v1/) if you need to upgrade your modules.
+
+#### Provider >= 1.0.0, < 1.4.0
+If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the [37b62b8](https://github.com/canonical/observability-stack/commit/37b62b863e1f288d760232bab634f41b8597d6bf) commit hash:
+
+```hcl
+module "cos" {
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=75f5e0bedde913a3f1c918be44716db8ef2c69a1"
+}
+```
+
+### Basic usage
+
 The minimum version of Terraform Juju provider required is `1.5`.
 
 To deploy the COS Lite solution in a model named `cos-lite`, create this root module:
@@ -66,14 +90,8 @@ terraform {
   }
 }
 
-resource "juju_model" "cos_lite" {
-  name = "cos-lite"
-}
-
 module "cos-lite" {
-  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=main"
-  model_uuid = juju_model.cos_lite.uuid
-  risk    = "edge"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite"
 }
 ```
 

--- a/terraform/cos-lite/README.md
+++ b/terraform/cos-lite/README.md
@@ -58,8 +58,9 @@ This is a Terraform module facilitating the deployment of the COS Lite solution,
 If you require the Terraform Juju provider `< 1.0.0`, then deploy the COS module with the `tf-provider-v0` tag:
 
 ```hcl
-module "cos" {
-  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=tf-provider-v0"
+module "cos-lite" {
+  source = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=tf-provider-v0"
+  # ... and other required variables ...
 }
 ```
 
@@ -69,8 +70,9 @@ Otherwise, you can deploy from main (without `?ref`) which supports the v1 Terra
 If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the [37b62b8](https://github.com/canonical/observability-stack/commit/37b62b863e1f288d760232bab634f41b8597d6bf) commit hash:
 
 ```hcl
-module "cos" {
-  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=37b62b863e1f288d760232bab634f41b8597d6bf"
+module "cos-lite" {
+  source = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=37b62b863e1f288d760232bab634f41b8597d6bf"
+  # ... and other required variables ...
 }
 ```
 
@@ -91,7 +93,7 @@ terraform {
 }
 
 module "cos-lite" {
-  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite"
+  source = "git::https://github.com/canonical/observability-stack//terraform/cos-lite"
 }
 ```
 

--- a/terraform/cos-lite/README.md
+++ b/terraform/cos-lite/README.md
@@ -71,7 +71,7 @@ If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module
 
 ```hcl
 module "cos-lite" {
-  source = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=37b62b863e1f288d760232bab634f41b8597d6bf"
+  source = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=c1c8bd9a17abe079242eb9535c6b7a4fa8832a02"
   # ... and other required variables ...
 }
 ```

--- a/terraform/cos-lite/terraform.tf
+++ b/terraform/cos-lite/terraform.tf
@@ -2,8 +2,10 @@ terraform {
   required_version = ">= 1.5"
   required_providers {
     juju = {
-      source  = "juju/juju"
-      version = ">= 1.0"
+      source = "juju/juju"
+      # This PR introduced the `juju_charm` resource released in v1.4.0:
+      #   https://github.com/canonical/observability-stack/pull/278
+      version = ">= 1.4.0"
     }
   }
 }

--- a/terraform/cos/README.md
+++ b/terraform/cos/README.md
@@ -89,7 +89,7 @@ If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module
 
 ```hcl
 module "cos" {
-  source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=75f5e0bedde913a3f1c918be44716db8ef2c69a1"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=c1c8bd9a17abe079242eb9535c6b7a4fa8832a02"
   # ... and other required variables ...
 }
 ```

--- a/terraform/cos/README.md
+++ b/terraform/cos/README.md
@@ -83,8 +83,8 @@ module "cos" {
 
 Otherwise, you can deploy from main (without `?ref`) which supports the v1 Terraform Juju provider. See the [v1 migration documentation](https://documentation.ubuntu.com/terraform-provider-juju/v1/howto/manage-provider/upgrade-provider-to-v1/) if you need to upgrade your modules.
 
-#### Provider <= v1.4.0
-If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the `75f5e0bedde913a3f1c918be44716db8ef2c69a1` commit hash:
+#### Provider >= 1.0.0, < 1.4.0
+If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the [75f5e0b](https://github.com/canonical/observability-stack/commit/75f5e0bedde913a3f1c918be44716db8ef2c69a1) commit hash:
 
 ```hcl
 module "cos" {
@@ -108,15 +108,8 @@ terraform {
   }
 }
 
-resource "juju_model" "cos" {
-  name = "cos"
-}
-
 module "cos" {
-  source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/2"
-  model_uuid = juju_model.cos.uuid
-  channel    = "2/stable"
-
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos"
   s3_endpoint   = "http://S3_HOST_IP:8080"
   s3_secret_key = "secret-key"
   s3_access_key = "access-key"

--- a/terraform/cos/README.md
+++ b/terraform/cos/README.md
@@ -85,7 +85,7 @@ module "cos" {
 Otherwise, you can deploy from main (without `?ref`) which supports the v1 Terraform Juju provider. See the [v1 migration documentation](https://documentation.ubuntu.com/terraform-provider-juju/v1/howto/manage-provider/upgrade-provider-to-v1/) if you need to upgrade your modules.
 
 #### Provider >= 1.0.0, < 1.4.0
-If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the [75f5e0b](https://github.com/canonical/observability-stack/commit/75f5e0bedde913a3f1c918be44716db8ef2c69a1) commit hash:
+If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the [c1c8bd9](https://github.com/canonical/observability-stack/commit/c1c8bd9a17abe079242eb9535c6b7a4fa8832a02) commit hash:
 
 ```hcl
 module "cos" {

--- a/terraform/cos/README.md
+++ b/terraform/cos/README.md
@@ -78,6 +78,7 @@ If you require the Terraform Juju provider `< 1.0.0`, then deploy the COS module
 ```hcl
 module "cos" {
   source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=tf-provider-v0"
+  # ... and other required variables ...
 }
 ```
 
@@ -89,6 +90,7 @@ If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module
 ```hcl
 module "cos" {
   source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=75f5e0bedde913a3f1c918be44716db8ef2c69a1"
+  # ... and other required variables ...
 }
 ```
 
@@ -153,11 +155,8 @@ In order to deploy COS on AWS, update the `cloud` input of the `cos` module to `
 
 ```hcl
 module "cos" {
-  source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/2"
-  model_uuid = juju_model.cos.uuid
-  channel    = "2/stable"
-  cloud      = "aws"
-
+  source        = "git::https://github.com/canonical/observability-stack//terraform/cos"
+  cloud         = "aws"
   s3_endpoint   = "http://S3_HOST_IP:8080"
   s3_secret_key = "secret-key"
   s3_access_key = "access-key"

--- a/terraform/cos/README.md
+++ b/terraform/cos/README.md
@@ -10,7 +10,7 @@ This is a Terraform module facilitating the deployment of the COS solution, usin
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.4.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -71,6 +71,8 @@ This is a Terraform module facilitating the deployment of the COS solution, usin
 ## Usage
 
 ### Using different Terraform Juju provider versions
+
+#### Provider v0
 If you require the Terraform Juju provider `< 1.0.0`, then deploy the COS module with the `tf-provider-v0` tag:
 
 ```hcl
@@ -79,7 +81,16 @@ module "cos" {
 }
 ```
 
-Otherwise, you can deploy from main (without `?ref`) which uses the Terraform Juju provider `~> 1.0`. See the [v1 migration documentation](https://documentation.ubuntu.com/terraform-provider-juju/v1/howto/manage-provider/upgrade-provider-to-v1/) if you need to upgrade your modules.
+Otherwise, you can deploy from main (without `?ref`) which supports the v1 Terraform Juju provider. See the [v1 migration documentation](https://documentation.ubuntu.com/terraform-provider-juju/v1/howto/manage-provider/upgrade-provider-to-v1/) if you need to upgrade your modules.
+
+#### Provider <= v1.4.0
+If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the `75f5e0bedde913a3f1c918be44716db8ef2c69a1` commit hash:
+
+```hcl
+module "cos" {
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=75f5e0bedde913a3f1c918be44716db8ef2c69a1"
+}
+```
 
 ### Basic usage
 

--- a/terraform/cos/terraform.tf
+++ b/terraform/cos/terraform.tf
@@ -2,8 +2,10 @@ terraform {
   required_version = ">= 1.5"
   required_providers {
     juju = {
-      source  = "juju/juju"
-      version = ">= 1.0"
+      source = "juju/juju"
+      # This PR introduced the `juju_charm` resource released in v1.4.0:
+      #   https://github.com/canonical/observability-stack/pull/278
+      version = ">= 1.4.0"
     }
   }
 }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes partially, https://github.com/canonical/observability-stack/issues/391

Since [the juju_charm datasource was added in COS and COS Lite](https://github.com/canonical/observability-stack/commit/75f5e0bedde913a3f1c918be44716db8ef2c69a1): a feature introduced in the [TF Juju provider v1.4.0](https://github.com/juju/terraform-provider-juju/releases/tag/v1.4.0), we need to update the requirements of the product modules to reflect that.

## Solution
<!-- A summary of the solution addressing the above issue -->
If you require the Terraform Juju provider `>= 1.0.0, < 1.4.0`, then deploy the COS (or COS Lite) module from the [c1c8bd9](https://github.com/canonical/observability-stack/commit/c1c8bd9a17abe079242eb9535c6b7a4fa8832a02) commit hash:

```hcl
module "cos-lite" {
  source = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=c1c8bd9a17abe079242eb9535c6b7a4fa8832a02"
}
```

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened
	- [ ] This is required
- [x] Test that the products deploy with the commit hashes

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
I tested this for both track/2 and main using the commit hashes prior to the juju_charm features:
- https://github.com/canonical/observability-stack/issues/391#issuecomment-4670805833

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
