### PR TITLE
fix: Remove SSC refs since it its versioning is fixed

### DIFF
--- a/terraform/cos-lite/README.md
+++ b/terraform/cos-lite/README.md
@@ -19,7 +19,7 @@ This is a Terraform module facilitating the deployment of the COS Lite solution,
 | <a name="module_grafana"></a> [grafana](#module\_grafana) | git::https://github.com/canonical/grafana-k8s-operator//terraform | n/a |
 | <a name="module_loki"></a> [loki](#module\_loki) | git::https://github.com/canonical/loki-k8s-operator//terraform | n/a |
 | <a name="module_prometheus"></a> [prometheus](#module\_prometheus) | git::https://github.com/canonical/prometheus-k8s-operator//terraform | n/a |
-| <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | 0216698683a757a44d02e98c003a19aa7ffcfb63 |
+| <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | rev653 |
 | <a name="module_traefik"></a> [traefik](#module\_traefik) | git::https://github.com/canonical/traefik-k8s-operator//terraform | n/a |
 
 ## Inputs

--- a/terraform/cos-lite/applications.tf
+++ b/terraform/cos-lite/applications.tf
@@ -70,8 +70,7 @@ module "prometheus" {
 }
 
 module "ssc" {
-  # The TF module bumped the Juju provider to v2 after this commit, pin for compatibility with provider v1 
-  source = "git::https://github.com/canonical/self-signed-certificates-operator//terraform?ref=0216698683a757a44d02e98c003a19aa7ffcfb63"
+  source = "git::https://github.com/canonical/self-signed-certificates-operator//terraform?ref=rev653"
   count  = var.internal_tls ? 1 : 0
 
   app_name    = var.ssc.app_name

--- a/terraform/cos/README.md
+++ b/terraform/cos/README.md
@@ -23,7 +23,7 @@ This is a Terraform module facilitating the deployment of the COS solution, usin
 | <a name="module_loki"></a> [loki](#module\_loki) | git::https://github.com/canonical/loki-operators//terraform | n/a |
 | <a name="module_mimir"></a> [mimir](#module\_mimir) | git::https://github.com/canonical/mimir-operators//terraform | n/a |
 | <a name="module_opentelemetry_collector"></a> [opentelemetry\_collector](#module\_opentelemetry\_collector) | git::https://github.com/canonical/opentelemetry-collector-k8s-operator//terraform | n/a |
-| <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | 0216698683a757a44d02e98c003a19aa7ffcfb63 |
+| <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | rev653 |
 | <a name="module_tempo"></a> [tempo](#module\_tempo) | git::https://github.com/canonical/tempo-operators//terraform | n/a |
 | <a name="module_traefik"></a> [traefik](#module\_traefik) | git::https://github.com/canonical/traefik-k8s-operator//terraform | n/a |
 

--- a/terraform/cos/applications.tf
+++ b/terraform/cos/applications.tf
@@ -128,8 +128,7 @@ module "opentelemetry_collector" {
 }
 
 module "ssc" {
-  # The TF module bumped the Juju provider to v2 after this commit, pin for compatibility with provider v1 
-  source = "git::https://github.com/canonical/self-signed-certificates-operator//terraform?ref=0216698683a757a44d02e98c003a19aa7ffcfb63"
+  source = "git::https://github.com/canonical/self-signed-certificates-operator//terraform?ref=rev653"
   count  = var.internal_tls ? 1 : 0
 
   app_name    = var.ssc.app_name


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
As mentioned in the original comment, the SSC maintainers had dependabot automation in place which bumped their requires to v2 for the provider breaking us. They since fixed it, as you can see with `terraform providers`:
```
.
├── provider[registry.terraform.io/juju/juju] ~> 1.0
└── module.cos_lite
    ├── provider[registry.terraform.io/juju/juju] >= 1.0.0
    ├── provider[terraform.io/builtin/terraform]
    ├── module.ssc
    │   └── provider[registry.terraform.io/juju/juju] ~> 1.0
```
```
.
├── provider[registry.terraform.io/juju/juju] >= 1.4.0
└── module.cos
    ├── provider[registry.terraform.io/juju/juju] >= 1.4.0
    ├── provider[terraform.io/builtin/terraform]
    ├── module.ssc
    │   └── provider[registry.terraform.io/juju/juju] ~> 1.0
```

## Solution
<!-- A summary of the solution addressing the above issue -->
Remove those commit hash pins, replacing them with charm revision pins since we have nothing better to pin to.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
