### PR TITLE
fix(track/2)!: Terraform Juju provider pin

### DIFF
--- a/terraform/cos-lite/README.md
+++ b/terraform/cos-lite/README.md
@@ -7,7 +7,7 @@ This is a Terraform module facilitating the deployment of the COS Lite solution,
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.4.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -50,15 +50,28 @@ This is a Terraform module facilitating the deployment of the COS Lite solution,
 ## Usage
 
 ### Using different Terraform Juju provider versions
-If you require the Terraform Juju provider `< 1.0.0`, then deploy the COS Lite module with the `tf-provider-v0` tag:
+
+#### Provider v0
+If you require the Terraform Juju provider `< 1.0.0`, then deploy the COS module with the `tf-provider-v0` tag:
 
 ```hcl
 module "cos-lite" {
-  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=tf-provider-v0"
+  source = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=tf-provider-v0"
+  # ... and other required variables ...
 }
 ```
 
-Otherwise, you can deploy from main (without `?ref`) which uses the Terraform Juju provider `~> 1.0`. See the [v1 migration documentation](https://documentation.ubuntu.com/terraform-provider-juju/v1/howto/manage-provider/upgrade-provider-to-v1/) if you need to upgrade your modules.
+Otherwise, you can deploy from main (without `?ref`) which supports the v1 Terraform Juju provider. See the [v1 migration documentation](https://documentation.ubuntu.com/terraform-provider-juju/v1/howto/manage-provider/upgrade-provider-to-v1/) if you need to upgrade your modules.
+
+#### Provider >= 1.0.0, < 1.4.0
+If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the [7448dad](https://github.com/canonical/observability-stack/commit/7448dadb996835c1c0ae1d79d2f435992652d410) commit hash:
+
+```hcl
+module "cos-lite" {
+  source = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=7448dadb996835c1c0ae1d79d2f435992652d410"
+  # ... and other required variables ...
+}
+```
 
 ### Basic usage
 

--- a/terraform/cos-lite/versions.tf
+++ b/terraform/cos-lite/versions.tf
@@ -2,8 +2,10 @@ terraform {
   required_version = ">= 1.5"
   required_providers {
     juju = {
-      source  = "juju/juju"
-      version = "~> 1.0"
+      source = "juju/juju"
+      # This PR introduced the `juju_charm` resource released in v1.4.0:
+      #   https://github.com/canonical/observability-stack/pull/304
+      version = ">= 1.4.0"
     }
   }
 }

--- a/terraform/cos/README.md
+++ b/terraform/cos/README.md
@@ -10,7 +10,7 @@ This is a Terraform module facilitating the deployment of the COS solution, usin
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.4.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -69,15 +69,26 @@ This is a Terraform module facilitating the deployment of the COS solution, usin
 ## Usage
 
 ### Using different Terraform Juju provider versions
+
+#### Provider v0
 If you require the Terraform Juju provider `< 1.0.0`, then deploy the COS module with the `tf-provider-v0` tag:
 
 ```hcl
 module "cos" {
   source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=tf-provider-v0"
+  # ... and other required variables ...
 }
 ```
 
-Otherwise, you can deploy from main (without `?ref`) which uses the Terraform Juju provider `~> 1.0`. See the [v1 migration documentation](https://documentation.ubuntu.com/terraform-provider-juju/v1/howto/manage-provider/upgrade-provider-to-v1/) if you need to upgrade your modules.
+#### Provider >= 1.0.0, < 1.4.0
+If you require the Terraform Juju provider `< 1.4.0`, then deploy the COS module from the [7448dad](https://github.com/canonical/observability-stack/commit/7448dadb996835c1c0ae1d79d2f435992652d410) commit hash:
+
+```hcl
+module "cos" {
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=7448dadb996835c1c0ae1d79d2f435992652d410"
+  # ... and other required variables ...
+}
+```
 
 ### Basic usage
 

--- a/terraform/cos/versions.tf
+++ b/terraform/cos/versions.tf
@@ -2,8 +2,10 @@ terraform {
   required_version = ">= 1.5"
   required_providers {
     juju = {
-      source  = "juju/juju"
-      version = "~> 1.0"
+      source = "juju/juju"
+      # This PR introduced the `juju_charm` resource released in v1.4.0:
+      #   https://github.com/canonical/observability-stack/pull/304
+      version = ">= 1.4.0"
     }
   }
 }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Backport this PR:
- https://github.com/canonical/observability-stack/pull/396

into track/2.

## Solution
<!-- A summary of the solution addressing the above issue -->
There is a subtle difference between main and track/2: the commit hash users have to pin to. This is [explained here](https://github.com/canonical/observability-stack/issues/391#issuecomment-4663077207).

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Tested in this issue comment:
- https://github.com/canonical/observability-stack/issues/391#issuecomment-4670805833