### PR TITLE
fix: Grafana scaled to 1 unit allows psql offer

### DIFF
--- a/terraform/cos/integrations.tf
+++ b/terraform/cos/integrations.tf
@@ -520,7 +520,7 @@ resource "juju_integration" "external_ca_cert" {
 # -------------- # Database --------------
 
 resource "juju_integration" "grafana_database" {
-  count = local.grafana_db_required ? 1 : 0
+  count = local.grafana_db_enabled ? 1 : 0
 
   model_uuid = local.model_uuid
 

--- a/terraform/cos/locals.tf
+++ b/terraform/cos/locals.tf
@@ -2,7 +2,7 @@ locals {
   create_model          = var.model.uuid == null
   model_uuid            = local.create_model ? juju_model.cos[0].uuid : data.juju_model.cos[0].uuid
   clouds                = ["aws", "self-managed"] # list of k8s clouds where this COS module can be deployed.
-  grafana_db_required   = var.grafana.units > 1
+  grafana_db_enabled    = var.postgresql_offer_url != null
   tls_termination       = var.external_certificates_offer_url != null ? true : false
   reverse_proxy_enabled = anytrue(values(var.ingress))
   traefik_enabled       = local.reverse_proxy_enabled

--- a/terraform/cos/tests/grafana_database.tftest.hcl
+++ b/terraform/cos/tests/grafana_database.tftest.hcl
@@ -24,7 +24,23 @@ run "grafana_conditionally_integrated_to_database_offer" {
 
   assert {
     condition     = length(juju_integration.grafana_database) == 1
-    error_message = "Expected a grafana_database integration when scale is > 1"
+    error_message = "Expected a grafana_database integration when an offer URL is supplied"
+  }
+}
+
+# --- grafana: scale 1 with database offer integration ---
+
+run "grafana_scale_1_integrated_to_database_offer" {
+  command = plan
+
+  variables {
+    grafana              = { units = 1 }
+    postgresql_offer_url = "admin/postgresql.database"
+  }
+
+  assert {
+    condition     = length(juju_integration.grafana_database) == 1
+    error_message = "Expected a grafana_database integration when an offer URL is supplied at scale 1"
   }
 }
 
@@ -37,6 +53,6 @@ run "grafana_scale_1_no_database_offer" {
 
   assert {
     condition     = length(juju_integration.grafana_database) == 0
-    error_message = "Unexpected grafana_database integrations when scale is 1"
+    error_message = "Unexpected grafana_database integrations when no offer URL is supplied"
   }
 }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This PR:
- https://github.com/canonical/observability-stack/pull/401

is great, but has a small flaw: the PSQL integration to Grafana should be dependent on the existence of the `postgresql_offer_url`, not the unit count being greater than 1. A valid use case would be to:
1. deploy COS by default which requires PSQL offer and has 3 Grafana units.
2. the user decides they want to scale down Grafana, but still wants to use PSQL as the database.

## Solution
<!-- A summary of the solution addressing the above issue -->
`grafana_db_enabled` is now solely dependent on the existence of the offer URL.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [x] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Added a unit test.
