### PR TITLE
fix: Otelcol log assertions after active/idle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,5 @@ version = "0.0.0"
 dependencies = [
   "jubilant",
   "pytest",
+  "sh",
 ]

--- a/tests/integration/cos_lite/tls_none/track-2.tf
+++ b/tests/integration/cos_lite/tls_none/track-2.tf
@@ -1,3 +1,4 @@
+# TODO: Remove when done testing
 terraform {
   required_version = ">= 1.5"
   required_providers {

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,15 +1,20 @@
 import json
+import logging
 import os
 import re
 import shlex
 import shutil
 import ssl
 import subprocess
+import time
 from pathlib import Path
 from typing import List, Optional
 from urllib.request import urlopen
 
 import jubilant
+import sh
+
+logger = logging.getLogger(__name__)
 
 
 class TfDirManager:
@@ -53,7 +58,11 @@ def generic_assertions(
         raise ValueError("temp_path is required when ca_model is provided")
     models = [ca_model, cos_model] if ca_model is not None else [cos_model]
     wait_for_active_idle_without_error(models, timeout=60 * 60)
-    tls_ctx = get_tls_context(temp_path, ca_model, "self-signed-certificates") if ca_model is not None else None
+    tls_ctx = (
+        get_tls_context(temp_path, ca_model, "self-signed-certificates")
+        if ca_model is not None
+        else None
+    )
     catalogue_apps_are_reachable(cos_model, tls_ctx)
 
 
@@ -110,24 +119,39 @@ def catalogue_apps_are_reachable(
 # 2026-04-22T12:00:54.179Z [otelcol] 2026-04-22T12:00:54.179Z info memorylimiter@v0.130.1/memorylimiter.go:171 Memory usage after GC. {"resource": {"service.instance.id": "9f774ce2-bbdd-44b8-95aa-abe1bd6b72eb", "service.name": "otelcol", "service.version": "0.130.1"}, "otelcol.component.id": "memory_limiter", "otelcol.component.kind": "processor", "otelcol.pipeline.id": "traces/otelcol/0", "otelcol.signal": "traces", "cur_mem_mib": 11}
 # 2026-04-22T12:08:54.309Z [otelcol] 2026-04-22T12:08:54.309Z error adapter/receiver.go:61 ConsumeLogs() failed {"resource": {"service.instance.id": "9f774ce2-bbdd-44b8-95aa-abe1bd6b72eb", "service.name": "otelcol", "service.version": "0.130.1"}, "otelcol.component.id": "filelog/var-log", "otelcol.component.kind": "receiver", "otelcol.signal": "logs", "error": "data refused due to high memory usage"}
 _LOG_LEVEL_RE = re.compile(
-    r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z \[otelcol\] \d{4}-\d{2}-\d{2}T[\d:.]+Z\t(\w+)\t"  # pebble format
+    r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z \[otelcol\] \d{4}-\d{2}-\d{2}T[\d:.]+Z(?:\\t|\s+)(\w+)(?:\\t|\s+)"  # pebble format (handles raw & escaped tabs)
     r"|^\d{4}-\d{2}-\d{2}T[\d:.]+Z (\w+) "  # raw otelcol format
 )
 
 
-def no_errors_in_otelcol_logs(juju: jubilant.Juju):
-    stdout = juju.ssh("otelcol/0", "pebble logs", container="otelcol")
-    assert stdout, "no logs found for otelcol"
-    _no_errors_in_otelcol_logs(stdout)
+def no_errors_in_otelcol_logs(juju: jubilant.Juju, lookback_window: int = 60 * 5):
+    """Capture only new logs for a specified duration, checking for error logs from otelcol."""
+    logger.info(
+        f"Following otelcol logs for {lookback_window} seconds to check for errors ..."
+    )
+    time.sleep(lookback_window)
+    logs = sh.kubectl.logs(
+        "otelcol-0", container="otelcol", n=juju.model, since=f"{lookback_window}s"
+    )
+    assert logs, "no logs found for otelcol"
+    _no_errors_in_otelcol_logs(logs)
 
 
-def _no_errors_in_otelcol_logs(stdout: str):
+def _no_errors_in_otelcol_logs(logs: str):
+    assert "[otelcol]" in logs, (
+        "no otelcol logs found; has the pebble log format changed?"
+    )
     matched_lines = [
         (m.group(1) or m.group(2), line)
-        for line in stdout.splitlines()
+        for line in logs.splitlines()
         if (m := _LOG_LEVEL_RE.match(line))
     ]
-    info_lines = [line for level, line in matched_lines if level == "info"]
-    assert info_lines, "no 'info' level logs found in otelcol output"
     error_lines = [line for level, line in matched_lines if level in ("warn", "error")]
     assert not error_lines, "otelcol error logs:\n" + "\n".join(error_lines)
+    # this INFO assertion ensures that the regex is correctly capturing log levels; avoids checking
+    # an empty set of logs due to a regex mismatch or log format change
+    info_lines = [line for level, line in matched_lines if level == "info"]
+    assert info_lines, (
+        "no 'info' level logs found in otelcol output, see logs:\n"
+        + "\n".join(logs.splitlines())
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -51,12 +51,14 @@ source = { virtual = "." }
 dependencies = [
     { name = "jubilant" },
     { name = "pytest" },
+    { name = "sh" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "jubilant" },
     { name = "pytest" },
+    { name = "sh" },
 ]
 
 [[package]]
@@ -166,6 +168,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "sh"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/56/6cedf4704590ac9c8ab57089ffa95895c21e82499981008ad369c43c9cc4/sh-2.3.0.tar.gz", hash = "sha256:402af9087bf8a5557562913ca83d715bfa0646cb93865c5d60c5578b07b17871", size = 135995, upload-time = "2026-06-09T04:22:34.431Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/85/d06247fc88ba278227397da5604287e4762f130347dc968f6d205eb15ee6/sh-2.3.0-py3-none-any.whl", hash = "sha256:9b9c51f988fa91ba09e2a78edc48810d0b5a34c8cf383408e4e8c4352169f26e", size = 48045, upload-time = "2026-06-09T04:22:33.069Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
After reviewing a few failed otelcol log assertions:
- https://github.com/canonical/observability-stack/actions/runs/27646660024/job/81760739360?pr=407
- https://github.com/canonical/observability-stack/actions/runs/27646660024/job/81760739527?pr=407
- https://github.com/canonical/observability-stack/actions/runs/27646660024/job/81760739446?pr=407

There was no guarantee that otelcol was looking at only Pebble logs since active/idle.

## Solution
<!-- A summary of the solution addressing the above issue -->
- To avoid asserting against otelcol logs which were gathered during the model settle period, we use `kubectl logs --since 60 * 5` to get the last 5 minutes worth of logs and assert against that.
- The regex pattern was extended to include the kubectl log format.
- The info log assertion was moved after the error assertion which is more accurate since only error logs might cause no info logs.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [x] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This assertion only exists on track/dev so no backport is required.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
See the CI