### PR TITLE
fix: Otelcol log assertions since active/idle

### DIFF
--- a/tests/integration/cos_lite/tls_none/track-2.tf
+++ b/tests/integration/cos_lite/tls_none/track-2.tf
@@ -1,3 +1,4 @@
+# TODO: Remove once done testing 
 terraform {
   required_version = ">= 1.5"
   required_providers {

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -137,6 +137,7 @@ def _logs_newer_than(logs: str, timestamp: str) -> List[str]:
 
 def no_errors_in_otelcol_logs(juju: jubilant.Juju, lookback_window: int = 60 * 5):
     """Sleep for lookback_window, then assert otelcol logged no errors during it."""
+    breakpoint()
     baseline = juju.ssh("otelcol/0", "pebble logs -n 1", container="otelcol")
     assert baseline, "no logs found for otelcol"
     # Pebble timestamp (first field) of the most recent log line; new lines sort above it.
@@ -160,5 +161,7 @@ def _no_errors_in_otelcol_logs(logs: List[str]):
     ]
     error_lines = [line for level, line in matched_lines if level in ("warn", "error")]
     assert not error_lines, "otelcol error logs:\n" + "\n".join(error_lines)
+    # this INFO assertion ensures that the regex is correctly capturing log levels; avoids checking
+    # an empty set of logs due to a regex mismatch or log format change
     info_lines = [line for level, line in matched_lines if level == "info"]
     assert info_lines, "no 'info' level logs found in otelcol output"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -140,7 +140,7 @@ def no_errors_in_otelcol_logs(juju: jubilant.Juju, lookback_window: int = 60 * 2
     stdout = juju.ssh("otelcol/0", "pebble logs -n all", container="otelcol")
     assert stdout, "no logs found for otelcol"
     logs = _logs_newer_than(stdout, latest_log_ts)
-    # no new logs is a good sign
+    # no new logs is a good sign, as long as the lookback_window is sufficiently long
     _no_errors_in_otelcol_logs(logs)
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -136,19 +136,20 @@ def _logs_newer_than(logs: str, timestamp: str) -> List[str]:
 
 
 def no_errors_in_otelcol_logs(juju: jubilant.Juju, lookback_window: int = 60 * 5):
-    """Capture only new logs for a specified duration, checking for error logs from otelcol."""
+    """Sleep for lookback_window, then assert otelcol logged no errors during it."""
     breakpoint()
-    stdout = juju.ssh("otelcol/0", "pebble logs -n 1", container="otelcol")
-    assert stdout, "no logs found for otelcol"
-    # TODO: Get the timestamp of the latest log to compare against future log lines
-    latest_log_ts = _LOG_LEVEL_RE.match(stdout)
+    baseline = juju.ssh("otelcol/0", "pebble logs -n 1", container="otelcol")
+    assert baseline, "no logs found for otelcol"
+    # Pebble timestamp (first field) of the most recent log line; new lines sort above it.
+    latest_log_ts = baseline.split(" ", 1)[0]
     logger.info(
         f"Following otelcol logs for {lookback_window} seconds to check for errors ..."
     )
     time.sleep(lookback_window)
-    stdout = juju.ssh("otelcol/0", "pebble logs", container="otelcol")
+    stdout = juju.ssh("otelcol/0", "pebble logs -n all", container="otelcol")
     assert stdout, "no logs found for otelcol"
     logs = _logs_newer_than(stdout, latest_log_ts)
+    assert logs, "no new logs found for otelcol since baseline"
     _no_errors_in_otelcol_logs(logs)
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -159,7 +159,7 @@ def _no_errors_in_otelcol_logs(logs: List[str]):
         for line in logs
         if (m := _LOG_LEVEL_RE.match(line))
     ]
-    info_lines = [line for level, line in matched_lines if level == "info"]
-    assert info_lines, "no 'info' level logs found in otelcol output"
     error_lines = [line for level, line in matched_lines if level in ("warn", "error")]
     assert not error_lines, "otelcol error logs:\n" + "\n".join(error_lines)
+    info_lines = [line for level, line in matched_lines if level == "info"]
+    assert info_lines, "no 'info' level logs found in otelcol output"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -137,7 +137,6 @@ def _logs_newer_than(logs: str, timestamp: str) -> List[str]:
 
 def no_errors_in_otelcol_logs(juju: jubilant.Juju, lookback_window: int = 60 * 5):
     """Sleep for lookback_window, then assert otelcol logged no errors during it."""
-    breakpoint()
     baseline = juju.ssh("otelcol/0", "pebble logs -n 1", container="otelcol")
     assert baseline, "no logs found for otelcol"
     # Pebble timestamp (first field) of the most recent log line; new lines sort above it.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -123,6 +123,33 @@ _LOG_LEVEL_RE = re.compile(
 )
 
 
+def no_errors_in_otelcol_logs(juju: jubilant.Juju, lookback_window: int = 60 * 2):
+    """Sleep for lookback_window, then assert otelcol logged no errors during it."""
+    baseline = juju.ssh("otelcol/0", "pebble logs -n 1", container="otelcol")
+    assert baseline, "no logs found for otelcol"
+    # confirm the regex parses a level out of a real log line
+    assert _log_level(baseline) in ("debug", "info", "warn", "error"), (
+        f"could not parse log level from: {baseline}"
+    )
+    # Pebble timestamp of the most recent log line
+    latest_log_ts = baseline.split(" ", 1)[0]
+    logger.info(
+        f"Following otelcol logs for {lookback_window} seconds to check for errors ..."
+    )
+    time.sleep(lookback_window)
+    stdout = juju.ssh("otelcol/0", "pebble logs -n all", container="otelcol")
+    assert stdout, "no logs found for otelcol"
+    logs = _logs_newer_than(stdout, latest_log_ts)
+    # no new logs is a good sign
+    _no_errors_in_otelcol_logs(logs)
+
+
+def _log_level(line: str) -> Optional[str]:
+    """Parse the log level from an otelcol log line, or None if it doesn't match."""
+    m = _LOG_LEVEL_RE.match(line)
+    return (m.group(1) or m.group(2)) if m else None
+
+
 def _logs_newer_than(logs: str, timestamp: str) -> List[str]:
     """Filter log lines to only include those newer than the specified timestamp."""
     newer_logs = []
@@ -135,33 +162,6 @@ def _logs_newer_than(logs: str, timestamp: str) -> List[str]:
     return newer_logs
 
 
-def no_errors_in_otelcol_logs(juju: jubilant.Juju, lookback_window: int = 60 * 5):
-    """Sleep for lookback_window, then assert otelcol logged no errors during it."""
-    breakpoint()
-    baseline = juju.ssh("otelcol/0", "pebble logs -n 1", container="otelcol")
-    assert baseline, "no logs found for otelcol"
-    # Pebble timestamp (first field) of the most recent log line; new lines sort above it.
-    latest_log_ts = baseline.split(" ", 1)[0]
-    logger.info(
-        f"Following otelcol logs for {lookback_window} seconds to check for errors ..."
-    )
-    time.sleep(lookback_window)
-    stdout = juju.ssh("otelcol/0", "pebble logs -n all", container="otelcol")
-    assert stdout, "no logs found for otelcol"
-    logs = _logs_newer_than(stdout, latest_log_ts)
-    assert logs, "no new logs found for otelcol since baseline"
-    _no_errors_in_otelcol_logs(logs)
-
-
 def _no_errors_in_otelcol_logs(logs: List[str]):
-    matched_lines = [
-        (m.group(1) or m.group(2), line)
-        for line in logs
-        if (m := _LOG_LEVEL_RE.match(line))
-    ]
-    error_lines = [line for level, line in matched_lines if level in ("warn", "error")]
+    error_lines = [line for line in logs if _log_level(line) in ("warn", "error")]
     assert not error_lines, "otelcol error logs:\n" + "\n".join(error_lines)
-    # this INFO assertion ensures that the regex is correctly capturing log levels; avoids checking
-    # an empty set of logs due to a regex mismatch or log format change
-    info_lines = [line for level, line in matched_lines if level == "info"]
-    assert info_lines, "no 'info' level logs found in otelcol output"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,15 +1,19 @@
 import json
+import logging
 import os
 import re
 import shlex
 import shutil
 import ssl
 import subprocess
+import time
 from pathlib import Path
 from typing import List, Optional
 from urllib.request import urlopen
 
 import jubilant
+
+logger = logging.getLogger(__name__)
 
 
 class TfDirManager:
@@ -53,7 +57,11 @@ def generic_assertions(
         raise ValueError("temp_path is required when ca_model is provided")
     models = [ca_model, cos_model] if ca_model is not None else [cos_model]
     wait_for_active_idle_without_error(models, timeout=60 * 60)
-    tls_ctx = get_tls_context(temp_path, ca_model, "self-signed-certificates") if ca_model is not None else None
+    tls_ctx = (
+        get_tls_context(temp_path, ca_model, "self-signed-certificates")
+        if ca_model is not None
+        else None
+    )
     catalogue_apps_are_reachable(cos_model, tls_ctx)
 
 
@@ -115,16 +123,39 @@ _LOG_LEVEL_RE = re.compile(
 )
 
 
-def no_errors_in_otelcol_logs(juju: jubilant.Juju):
+def _logs_newer_than(logs: str, timestamp: str) -> List[str]:
+    """Filter log lines to only include those newer than the specified timestamp."""
+    newer_logs = []
+    for line in logs.splitlines():
+        m = _LOG_LEVEL_RE.match(line)
+        if m:
+            log_ts_str = line.split(" ")[0]
+            if log_ts_str > timestamp:
+                newer_logs.append(line)
+    return newer_logs
+
+
+def no_errors_in_otelcol_logs(juju: jubilant.Juju, lookback_window: int = 60 * 5):
+    """Capture only new logs for a specified duration, checking for error logs from otelcol."""
+    breakpoint()
+    stdout = juju.ssh("otelcol/0", "pebble logs -n 1", container="otelcol")
+    assert stdout, "no logs found for otelcol"
+    # TODO: Get the timestamp of the latest log to compare against future log lines
+    latest_log_ts = _LOG_LEVEL_RE.match(stdout)
+    logger.info(
+        f"Following otelcol logs for {lookback_window} seconds to check for errors ..."
+    )
+    time.sleep(lookback_window)
     stdout = juju.ssh("otelcol/0", "pebble logs", container="otelcol")
     assert stdout, "no logs found for otelcol"
-    _no_errors_in_otelcol_logs(stdout)
+    logs = _logs_newer_than(stdout, latest_log_ts)
+    _no_errors_in_otelcol_logs(logs)
 
 
-def _no_errors_in_otelcol_logs(stdout: str):
+def _no_errors_in_otelcol_logs(logs: List[str]):
     matched_lines = [
         (m.group(1) or m.group(2), line)
-        for line in stdout.splitlines()
+        for line in logs
         if (m := _LOG_LEVEL_RE.match(line))
     ]
     info_lines = [line for level, line in matched_lines if level == "info"]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
After reviewing a few failed otelcol log assertions:
- https://github.com/canonical/observability-stack/actions/runs/27646660024/job/81760739360?pr=407
- https://github.com/canonical/observability-stack/actions/runs/27646660024/job/81760739527?pr=407
- https://github.com/canonical/observability-stack/actions/runs/27646660024/job/81760739446?pr=407

There was no guarantee that otelcol was looking at only Pebble logs since active/idle.

## Solution
<!-- A summary of the solution addressing the above issue -->
- To avoid asserting against otelcol logs which were gathered during the model settle period, we get the last 5 minutes worth of logs and assert against that.
- The info log assertion was moved after the error assertion which is more accurate since only error logs might cause no info logs.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [x] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This PR superceeds this one:
- https://github.com/canonical/observability-stack/pull/412

This assertion only exists on track/dev so no backport is required.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
See CI itests.