### PR TITLE
feat: sqa_tests for product assertions on prod infra

### DIFF
--- a/sqa_tests
+++ b/sqa_tests
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
 
-juju wait-for model cos --timeout=60m --query='forEach(applications, app => app.status == "active")' > test_results.raw
+juju wait-for model cos --timeout=60m --query='forEach(applications, app => app.status == "active")'
 
 exit

--- a/sqa_tests
+++ b/sqa_tests
@@ -2,3 +2,5 @@
 set -ex
 
 juju wait-for model cos --timeout=60m --query='forEach(applications, app => app.status == "active")' > test_results.raw
+
+exit

--- a/sqa_tests
+++ b/sqa_tests
@@ -1,11 +1,4 @@
 #!/bin/bash
 set -ex
 
-sudo snap install go --classic
-go install github.com/tebeka/go2xunit@v1.4.10
-
-juju wait-for model cos --timeout=60m --query='forEach(applications, app => app.status == "active")'
-
-~/go/bin/go2xunit -input test_results.raw -output test_results.xml
-
-exit
+juju wait-for model cos --timeout=60m --query='forEach(applications, app => app.status == "active")' > test_results.raw

--- a/sqa_tests
+++ b/sqa_tests
@@ -1,53 +1,11 @@
 #!/bin/bash
 set -ex
 
-TF_JUJU_QA_CTRL="tfqa"
-TF_JUJU_QA_OFFERING_CTRL="tfqa-offering"
-CLUSTER_TAG="sqa-$CLUSTER"
-
 sudo snap install go --classic
-sudo snap install terraform --classic
-sudo snap install yq --classic
-sudo snap install kubectl --classic
 go install github.com/tebeka/go2xunit@v1.4.10
 
-# MAAS credentials
-read -r api_name api_url api_key <<< "$(maas list)"
-
-cat > "./clouds.yaml" << EOF
-clouds:
-    maas-cloud:
-        type: maas
-        auth-types: [oauth1]
-        endpoint: $api_url
-EOF
-juju add-cloud --client --file ./clouds.yaml
-rm -f ./clouds.yaml
-trap "juju remove-cloud maas-cloud" EXIT
-
-cat > "./creds.yaml" << EOF
-credentials:
-    maas-cloud:
-        maas-creds:
-            auth-type: oauth1
-            maas-oauth: $api_key
-EOF
-juju add-credential --client --file ./creds.yaml maas-cloud
-rm -f ./creds.yaml
-trap "juju remove-credential maas-cloud maas-creds" EXIT
-
-juju bootstrap --credential maas-creds maas-cloud $TF_JUJU_QA_CTRL --constraints "tags=juju,$CLUSTER_TAG"
-trap "juju kill-controller --no-prompt $TF_JUJU_QA_CTRL" EXIT
-
-juju bootstrap --credential maas-creds maas-cloud $TF_JUJU_QA_OFFERING_CTRL --constraints "tags=juju_upgrade,$CLUSTER_TAG"
-trap "juju kill-controller --no-prompt $TF_JUJU_QA_OFFERING_CTRL" EXIT
-
-# Actually run machine tests
-# Tag name is just for picking machines, doesn't actually have vault running
-set +e
-TF_VAR_tags="vault,$CLUSTER_TAG" TF_VAR_cloud="maas-cloud" go test -v -timeout=8h ./tests_machine/... |& tee test_results.raw
-go_test_exit=${PIPESTATUS[0]}
-set -e
+juju wait-for model cos --timeout=60m --query='forEach(applications, app => app.status == "active")'
 
 ~/go/bin/go2xunit -input test_results.raw -output test_results.xml
-exit "$go_test_exit"
+
+exit

--- a/sqa_tests
+++ b/sqa_tests
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -ex
+
+TF_JUJU_QA_CTRL="tfqa"
+TF_JUJU_QA_OFFERING_CTRL="tfqa-offering"
+CLUSTER_TAG="sqa-$CLUSTER"
+
+sudo snap install go --classic
+sudo snap install terraform --classic
+sudo snap install yq --classic
+sudo snap install kubectl --classic
+go install github.com/tebeka/go2xunit@v1.4.10
+
+# MAAS credentials
+read -r api_name api_url api_key <<< "$(maas list)"
+
+cat > "./clouds.yaml" << EOF
+clouds:
+    maas-cloud:
+        type: maas
+        auth-types: [oauth1]
+        endpoint: $api_url
+EOF
+juju add-cloud --client --file ./clouds.yaml
+rm -f ./clouds.yaml
+trap "juju remove-cloud maas-cloud" EXIT
+
+cat > "./creds.yaml" << EOF
+credentials:
+    maas-cloud:
+        maas-creds:
+            auth-type: oauth1
+            maas-oauth: $api_key
+EOF
+juju add-credential --client --file ./creds.yaml maas-cloud
+rm -f ./creds.yaml
+trap "juju remove-credential maas-cloud maas-creds" EXIT
+
+juju bootstrap --credential maas-creds maas-cloud $TF_JUJU_QA_CTRL --constraints "tags=juju,$CLUSTER_TAG"
+trap "juju kill-controller --no-prompt $TF_JUJU_QA_CTRL" EXIT
+
+juju bootstrap --credential maas-creds maas-cloud $TF_JUJU_QA_OFFERING_CTRL --constraints "tags=juju_upgrade,$CLUSTER_TAG"
+trap "juju kill-controller --no-prompt $TF_JUJU_QA_OFFERING_CTRL" EXIT
+
+# Actually run machine tests
+# Tag name is just for picking machines, doesn't actually have vault running
+set +e
+TF_VAR_tags="vault,$CLUSTER_TAG" TF_VAR_cloud="maas-cloud" go test -v -timeout=8h ./tests_machine/... |& tee test_results.raw
+go_test_exit=${PIPESTATUS[0]}
+set -e
+
+~/go/bin/go2xunit -input test_results.raw -output test_results.xml
+exit "$go_test_exit"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We need SQA tests so that we at least know our deployments are active, not just deployed.

## Solution
<!-- A summary of the solution addressing the above issue -->
For both COS and COS Lite the model created on SolQA is called `cos` so it works for both and for `track/dev` and `track/n`. See these notes for a breakdown of SolQA infra/testing:
- https://github.com/canonical/observability-team/blob/main/how-to/test-products-with-solqa.md

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [x] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).
- [x] This PR has breaking changes to the product API(s) and I have created an issue in [SolQA pipelines](https://github.com/canonical/terragrunt-deployment-pipelines) to address this.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- https://github.com/canonical/terragrunt-deployment-pipelines/actions/runs/28136732680/job/83325143528#step:30:205

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
