### PR TITLE
feat: Better QA tests

### DIFF
--- a/sqa_tests
+++ b/sqa_tests
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -ex
+set -eu
 
-juju wait-for model cos --timeout=60m --query='forEach(applications, app => app.status == "active")'
-
-exit
+./tests/sqa/model-active

--- a/tests/sqa/model-active
+++ b/tests/sqa/model-active
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -eu
+
+MODEL="cos"
+QUERY='forEach(applications, app => app.status == "active")'
+
+# Overall deadline and how long each individual wait-for attempt runs before we
+# bail out to print status and try again.
+OVERALL_TIMEOUT=$((60 * 60)) # 60 minutes, in seconds
+POLL_TIMEOUT=30              # seconds per wait-for attempt
+
+start_time=$(date +%s)
+attempt=0
+
+while true; do
+    attempt=$((attempt + 1))
+    elapsed=$(($(date +%s) - start_time))
+    remaining=$((OVERALL_TIMEOUT - elapsed))
+
+    if [ "$remaining" -le 0 ]; then
+        echo "=========================================================="
+        echo "ERROR: model '${MODEL}' did not become active within ${OVERALL_TIMEOUT}s." >&2
+        echo "Final status:" >&2
+        juju status --model "${MODEL}" --relations || true
+        exit 1
+    fi
+
+    # Don't let a single attempt run past the overall deadline.
+    this_timeout=$POLL_TIMEOUT
+    if [ "$remaining" -lt "$this_timeout" ]; then
+        this_timeout=$remaining
+    fi
+
+    echo "=========================================================="
+    echo "Attempt ${attempt}: waiting up to ${this_timeout}s for model '${MODEL}' to be active (elapsed ${elapsed}s / ${OVERALL_TIMEOUT}s)..."
+
+    if juju wait-for model "${MODEL}" --timeout="${this_timeout}s" --query="${QUERY}"; then
+        echo "=========================================================="
+        echo "SUCCESS: model '${MODEL}' is active after ${attempt} attempt(s) (${elapsed}s)."
+        juju status --model "${MODEL}" --relations || true
+        exit 0
+    fi
+
+    # wait-for timed out (or otherwise failed); surface the current state so we
+    # can see *why* the model isn't active yet, then loop and try again.
+    echo "----------------------------------------------------------"
+    echo "Model '${MODEL}' not active yet; current status:"
+    juju status --model "${MODEL}" --relations || true
+done

--- a/tests/sqa/model-active
+++ b/tests/sqa/model-active
@@ -2,7 +2,9 @@
 set -eu
 
 MODEL="cos"
-QUERY='forEach(applications, app => app.status == "active")'
+# Require every application to be active *and* every unit to have an active
+# workload with an idle agent
+QUERY='forEach(applications, app => app.status == "active" && forEach(app.units, unit => unit.workload-status == "active" && unit.agent-status == "idle"))'
 
 # Overall deadline and how long each individual wait-for attempt runs before we
 # bail out to print status and try again.

--- a/tests/sqa/model-active
+++ b/tests/sqa/model-active
@@ -47,5 +47,5 @@ while true; do
     # can see *why* the model isn't active yet, then loop and try again.
     echo "----------------------------------------------------------"
     echo "Model '${MODEL}' not active yet; current status:"
-    juju status --model "${MODEL}" --relations || true
+    juju status --model "${MODEL}" || true
 done


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We need to know the status of the active/idle check.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add intermittent `juju status` to get insight on progress. Also, add agent idle assertion.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [x] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).
- [x] This PR has breaking changes to the product API(s) and I have created an issue in [SolQA pipelines](https://github.com/canonical/terragrunt-deployment-pipelines) to address this.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
```
charm-dev-y observability-stack fix/sqa-tests ($!)  took 3s 
❯ ./sqa_tests                    
==========================================================
Attempt 1: waiting up to 30s for model 'cos' to be active (elapsed 0s / 3600s)...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" found, waiting...
ERROR timed out waiting for "cos" to reach goal state
----------------------------------------------------------
Model 'cos' not active yet; current status:
Model  Controller  Cloud/Region  Version  SLA          Timestamp
cos    k8s         k8s           3.6.23   unsupported  10:55:36-04:00

App                      Version  Status  Scale  Charm                        Channel      Rev  Address         Exposed  Message
alertmanager             0.31.0   active      1  alertmanager-k8s             dev/edge     213  10.152.183.242  no       
catalogue                         active      1  catalogue-k8s                dev/edge     138  10.152.183.133  no       
grafana                  12.4.2   active      1  grafana-k8s                  dev/edge     188  10.152.183.21   no       
loki                              active      1  loki-coordinator-k8s         dev/edge      75  10.152.183.178  no       
loki-backend             3.7.1    active      1  loki-worker-k8s              dev/edge      85  10.152.183.164  no       backend ready.
loki-read                3.7.1    active      1  loki-worker-k8s              dev/edge      85  10.152.183.131  no       read ready.
loki-s3-integrator                active      1  s3-integrator                2/edge       550  10.152.183.204  no       
loki-write               3.7.1    active      1  loki-worker-k8s              dev/edge      85  10.152.183.65   no       write ready.
mimir                             active      1  mimir-coordinator-k8s        dev/edge      90  10.152.183.134  no       
mimir-backend            2.17.10  active      1  mimir-worker-k8s             dev/edge      79  10.152.183.139  no       backend ready.
mimir-read               2.17.10  active      1  mimir-worker-k8s             dev/edge      79  10.152.183.108  no       read ready.
mimir-s3-integrator               active      1  s3-integrator                2/edge       550  10.152.183.120  no       
mimir-write              2.17.10  active      1  mimir-worker-k8s             dev/edge      79  10.152.183.40   no       write ready.
otelcol                  0.130.1  active      1  opentelemetry-collector-k8s  dev/edge     188  10.152.183.86   no       
tempo                             active      1  tempo-coordinator-k8s        dev/edge     153  10.152.183.219  no       
tempo-compactor          2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.123  no       compactor ready.
tempo-distributor        2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.79   no       distributor ready.
tempo-ingester           2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.166  no       ingester ready.
tempo-metrics-generator  2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.249  no       metrics-generator ready.
tempo-querier            2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.51   no       querier ready.
tempo-query-frontend     2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.94   no       query-frontend ready.
tempo-s3-integrator               active      1  s3-integrator                2/edge       550  10.152.183.100  no       
traefik                           active      1  traefik-k8s                  latest/edge  338  10.152.183.163  no       Serving at http://10.212.157.240

Unit                        Workload  Agent      Address     Ports  Message
alertmanager/0*             active    idle       10.1.0.61          
catalogue/0*                active    idle       10.1.0.135         
grafana/0*                  active    idle       10.1.0.60          
loki-backend/0*             active    idle       10.1.0.121         backend ready.
loki-read/0*                active    idle       10.1.0.5           read ready.
loki-s3-integrator/0*       active    idle       10.1.0.184         
loki-write/0*               active    idle       10.1.0.163         write ready.
loki/0*                     active    idle       10.1.0.152         
mimir-backend/0*            active    idle       10.1.0.6           backend ready.
mimir-read/0*               active    idle       10.1.0.138         read ready.
mimir-s3-integrator/0*      active    idle       10.1.0.97          
mimir-write/0*              active    idle       10.1.0.206         write ready.
mimir/0*                    active    idle       10.1.0.212         
otelcol/0*                  active    idle       10.1.0.157         
tempo-compactor/0*          active    idle       10.1.0.93          compactor ready.
tempo-distributor/0*        active    idle       10.1.0.122         distributor ready.
tempo-ingester/0*           active    idle       10.1.0.62          ingester ready.
tempo-metrics-generator/0*  active    idle       10.1.0.194         metrics-generator ready.
tempo-querier/0*            active    idle       10.1.0.205         querier ready.
tempo-query-frontend/0*     active    idle       10.1.0.216         query-frontend ready.
tempo-s3-integrator/0*      active    idle       10.1.0.113         
tempo/0*                    active    idle       10.1.0.147         
traefik/0*                  active    executing  10.1.0.28          Serving at http://10.212.157.240

Offer                         Application   Charm                  Rev  Connected  Endpoint              Interface                Role
alertmanager-karma-dashboard  alertmanager  alertmanager-k8s       213  0/0        karma-dashboard       karma_dashboard          provider
grafana-dashboards            grafana       grafana-k8s            188  0/0        grafana-dashboard     grafana_dashboard        requirer
loki-logging                  loki          loki-coordinator-k8s   75   0/0        logging               loki_push_api            provider
mimir-receive-remote-write    mimir         mimir-coordinator-k8s  90   0/0        receive-remote-write  prometheus_remote_write  provider

Integration provider                 Requirer                               Interface                    Type     Message
alertmanager:alerting                loki:alertmanager                      alertmanager_dispatch        regular  
alertmanager:alerting                mimir:alertmanager                     alertmanager_dispatch        regular  
alertmanager:grafana-dashboard       grafana:grafana-dashboard              grafana_dashboard            regular  
alertmanager:grafana-source          grafana:grafana-source                 grafana_datasource           regular  
alertmanager:replicas                alertmanager:replicas                  alertmanager_replica         peer     
alertmanager:self-metrics-endpoint   otelcol:metrics-endpoint               prometheus_scrape            regular  
catalogue:catalogue                  alertmanager:catalogue                 catalogue                    regular  
catalogue:catalogue                  grafana:catalogue                      catalogue                    regular  
catalogue:catalogue                  mimir:catalogue                        catalogue                    regular  
catalogue:catalogue                  tempo:catalogue                        catalogue                    regular  
catalogue:replicas                   catalogue:replicas                     catalogue_replica            peer     
grafana:grafana                      grafana:grafana                        grafana_peers                peer     
grafana:replicas                     grafana:replicas                       grafana_replicas             peer     
loki-s3-integrator:s3-credentials    loki:s3                                s3                           regular  
loki-s3-integrator:status-peers      loki-s3-integrator:status-peers        status_peers                 peer     
loki:grafana-dashboards-provider     grafana:grafana-dashboard              grafana_dashboard            regular  
loki:grafana-source                  grafana:grafana-source                 grafana_datasource           regular  
loki:logging                         otelcol:send-loki-logs                 loki_push_api                regular  
loki:loki-cluster                    loki-backend:loki-cluster              loki_cluster                 regular  
loki:loki-cluster                    loki-read:loki-cluster                 loki_cluster                 regular  
loki:loki-cluster                    loki-write:loki-cluster                loki_cluster                 regular  
loki:loki-peers                      loki:loki-peers                        loki_peers                   peer     
loki:self-metrics-endpoint           otelcol:metrics-endpoint               prometheus_scrape            regular  
loki:send-datasource                 tempo:receive-datasource               grafana_datasource_exchange  regular  
mimir-s3-integrator:s3-credentials   mimir:s3                               s3                           regular  
mimir-s3-integrator:status-peers     mimir-s3-integrator:status-peers       status_peers                 peer     
mimir:grafana-dashboards-provider    grafana:grafana-dashboard              grafana_dashboard            regular  
mimir:grafana-source                 grafana:grafana-source                 grafana_datasource           regular  
mimir:mimir-cluster                  mimir-backend:mimir-cluster            mimir_cluster                regular  
mimir:mimir-cluster                  mimir-read:mimir-cluster               mimir_cluster                regular  
mimir:mimir-cluster                  mimir-write:mimir-cluster              mimir_cluster                regular  
mimir:mimir-peers                    mimir:mimir-peers                      mimir_peers                  peer     
mimir:receive-remote-write           otelcol:send-remote-write              prometheus_remote_write      regular  
mimir:receive-remote-write           tempo:send-remote-write                prometheus_remote_write      regular  
mimir:self-metrics-endpoint          otelcol:metrics-endpoint               prometheus_scrape            regular  
mimir:send-datasource                tempo:receive-datasource               grafana_datasource_exchange  regular  
otelcol:grafana-dashboards-provider  grafana:grafana-dashboard              grafana_dashboard            regular  
otelcol:peers                        otelcol:peers                          otelcol_replica              peer     
otelcol:receive-loki-logs            alertmanager:logging                   loki_push_api                regular  
otelcol:receive-loki-logs            grafana:logging                        loki_push_api                regular  
otelcol:receive-loki-logs            loki:logging-consumer                  loki_push_api                regular  
otelcol:receive-loki-logs            mimir:logging-consumer                 loki_push_api                regular  
otelcol:receive-loki-logs            tempo:logging                          loki_push_api                regular  
otelcol:receive-traces               grafana:charm-tracing                  tracing                      regular  
otelcol:receive-traces               loki:charm-tracing                     tracing                      regular  
otelcol:receive-traces               mimir:charm-tracing                    tracing                      regular  
tempo-s3-integrator:s3-credentials   tempo:s3                               s3                           regular  
tempo-s3-integrator:status-peers     tempo-s3-integrator:status-peers       status_peers                 peer     
tempo:grafana-dashboard              grafana:grafana-dashboard              grafana_dashboard            regular  
tempo:grafana-source                 grafana:grafana-source                 grafana_datasource           regular  
tempo:metrics-endpoint               otelcol:metrics-endpoint               prometheus_scrape            regular  
tempo:peers                          tempo:peers                            tempo_peers                  peer     
tempo:tempo-cluster                  tempo-compactor:tempo-cluster          tempo_cluster                regular  
tempo:tempo-cluster                  tempo-distributor:tempo-cluster        tempo_cluster                regular  
tempo:tempo-cluster                  tempo-ingester:tempo-cluster           tempo_cluster                regular  
tempo:tempo-cluster                  tempo-metrics-generator:tempo-cluster  tempo_cluster                regular  
tempo:tempo-cluster                  tempo-querier:tempo-cluster            tempo_cluster                regular  
tempo:tempo-cluster                  tempo-query-frontend:tempo-cluster     tempo_cluster                regular  
tempo:tracing                        otelcol:send-traces                    tracing                      regular  
traefik:ingress                      grafana:ingress                        ingress                      regular  
traefik:ingress                      loki:ingress                           ingress                      regular  
traefik:ingress                      mimir:ingress                          ingress                      regular  
traefik:peers                        traefik:peers                          traefik_peers                peer     
traefik:traefik-route                otelcol:ingress                        traefik_route                regular  
==========================================================
Attempt 2: waiting up to 30s for model 'cos' to be active (elapsed 32s / 3600s)...
model "cos" found, waiting...
model "cos" found, waiting...
model "cos" is running
properties: {}
applications:
  alertmanager:
    status: active
    units: {}
  catalogue:
    status: active
    units: {}
  grafana:
    status: active
    units: {}
  loki:
    status: active
    units: {}
  loki-backend:
    status: active
    units: {}
  loki-read:
    status: active
    units: {}
  loki-s3-integrator:
    status: active
    units: {}
  loki-write:
    status: active
    units: {}
  mimir:
    status: active
    units: {}
  mimir-backend:
    status: active
    units: {}
  mimir-read:
    status: active
    units: {}
  mimir-s3-integrator:
    status: active
    units: {}
  mimir-write:
    status: active
    units: {}
  otelcol:
    status: active
    units: {}
  tempo:
    status: active
    units: {}
  tempo-compactor:
    status: active
    units: {}
  tempo-distributor:
    status: active
    units: {}
  tempo-ingester:
    status: active
    units: {}
  tempo-metrics-generator:
    status: active
    units: {}
  tempo-querier:
    status: active
    units: {}
  tempo-query-frontend:
    status: active
    units: {}
  tempo-s3-integrator:
    status: active
    units: {}
  traefik:
    status: active
    units: {}
==========================================================
SUCCESS: model 'cos' is active after 2 attempt(s) (32s).
Model  Controller  Cloud/Region  Version  SLA          Timestamp
cos    k8s         k8s           3.6.23   unsupported  10:55:40-04:00

App                      Version  Status  Scale  Charm                        Channel      Rev  Address         Exposed  Message
alertmanager             0.31.0   active      1  alertmanager-k8s             dev/edge     213  10.152.183.242  no       
catalogue                         active      1  catalogue-k8s                dev/edge     138  10.152.183.133  no       
grafana                  12.4.2   active      1  grafana-k8s                  dev/edge     188  10.152.183.21   no       
loki                              active      1  loki-coordinator-k8s         dev/edge      75  10.152.183.178  no       
loki-backend             3.7.1    active      1  loki-worker-k8s              dev/edge      85  10.152.183.164  no       backend ready.
loki-read                3.7.1    active      1  loki-worker-k8s              dev/edge      85  10.152.183.131  no       read ready.
loki-s3-integrator                active      1  s3-integrator                2/edge       550  10.152.183.204  no       
loki-write               3.7.1    active      1  loki-worker-k8s              dev/edge      85  10.152.183.65   no       write ready.
mimir                             active      1  mimir-coordinator-k8s        dev/edge      90  10.152.183.134  no       
mimir-backend            2.17.10  active      1  mimir-worker-k8s             dev/edge      79  10.152.183.139  no       backend ready.
mimir-read               2.17.10  active      1  mimir-worker-k8s             dev/edge      79  10.152.183.108  no       read ready.
mimir-s3-integrator               active      1  s3-integrator                2/edge       550  10.152.183.120  no       
mimir-write              2.17.10  active      1  mimir-worker-k8s             dev/edge      79  10.152.183.40   no       write ready.
otelcol                  0.130.1  active      1  opentelemetry-collector-k8s  dev/edge     188  10.152.183.86   no       
tempo                             active      1  tempo-coordinator-k8s        dev/edge     153  10.152.183.219  no       
tempo-compactor          2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.123  no       compactor ready.
tempo-distributor        2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.79   no       distributor ready.
tempo-ingester           2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.166  no       ingester ready.
tempo-metrics-generator  2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.249  no       metrics-generator ready.
tempo-querier            2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.51   no       querier ready.
tempo-query-frontend     2.10.1   active      1  tempo-worker-k8s             dev/edge     107  10.152.183.94   no       query-frontend ready.
tempo-s3-integrator               active      1  s3-integrator                2/edge       550  10.152.183.100  no       
traefik                  2.11.49  active      1  traefik-k8s                  latest/edge  338  10.152.183.163  no       Serving at http://10.212.157.240

Unit                        Workload  Agent  Address     Ports  Message
alertmanager/0*             active    idle   10.1.0.61          
catalogue/0*                active    idle   10.1.0.135         
grafana/0*                  active    idle   10.1.0.60          
loki-backend/0*             active    idle   10.1.0.121         backend ready.
loki-read/0*                active    idle   10.1.0.5           read ready.
loki-s3-integrator/0*       active    idle   10.1.0.184         
loki-write/0*               active    idle   10.1.0.163         write ready.
loki/0*                     active    idle   10.1.0.152         
mimir-backend/0*            active    idle   10.1.0.6           backend ready.
mimir-read/0*               active    idle   10.1.0.138         read ready.
mimir-s3-integrator/0*      active    idle   10.1.0.97          
mimir-write/0*              active    idle   10.1.0.206         write ready.
mimir/0*                    active    idle   10.1.0.212         
otelcol/0*                  active    idle   10.1.0.157         
tempo-compactor/0*          active    idle   10.1.0.93          compactor ready.
tempo-distributor/0*        active    idle   10.1.0.122         distributor ready.
tempo-ingester/0*           active    idle   10.1.0.62          ingester ready.
tempo-metrics-generator/0*  active    idle   10.1.0.194         metrics-generator ready.
tempo-querier/0*            active    idle   10.1.0.205         querier ready.
tempo-query-frontend/0*     active    idle   10.1.0.216         query-frontend ready.
tempo-s3-integrator/0*      active    idle   10.1.0.113         
tempo/0*                    active    idle   10.1.0.147         
traefik/0*                  active    idle   10.1.0.28          Serving at http://10.212.157.240

Offer                         Application   Charm                  Rev  Connected  Endpoint              Interface                Role
alertmanager-karma-dashboard  alertmanager  alertmanager-k8s       213  0/0        karma-dashboard       karma_dashboard          provider
grafana-dashboards            grafana       grafana-k8s            188  0/0        grafana-dashboard     grafana_dashboard        requirer
loki-logging                  loki          loki-coordinator-k8s   75   0/0        logging               loki_push_api            provider
mimir-receive-remote-write    mimir         mimir-coordinator-k8s  90   0/0        receive-remote-write  prometheus_remote_write  provider

Integration provider                 Requirer                               Interface                    Type     Message
alertmanager:alerting                loki:alertmanager                      alertmanager_dispatch        regular  
alertmanager:alerting                mimir:alertmanager                     alertmanager_dispatch        regular  
alertmanager:grafana-dashboard       grafana:grafana-dashboard              grafana_dashboard            regular  
alertmanager:grafana-source          grafana:grafana-source                 grafana_datasource           regular  
alertmanager:replicas                alertmanager:replicas                  alertmanager_replica         peer     
alertmanager:self-metrics-endpoint   otelcol:metrics-endpoint               prometheus_scrape            regular  
catalogue:catalogue                  alertmanager:catalogue                 catalogue                    regular  
catalogue:catalogue                  grafana:catalogue                      catalogue                    regular  
catalogue:catalogue                  mimir:catalogue                        catalogue                    regular  
catalogue:catalogue                  tempo:catalogue                        catalogue                    regular  
catalogue:replicas                   catalogue:replicas                     catalogue_replica            peer     
grafana:grafana                      grafana:grafana                        grafana_peers                peer     
grafana:replicas                     grafana:replicas                       grafana_replicas             peer     
loki-s3-integrator:s3-credentials    loki:s3                                s3                           regular  
loki-s3-integrator:status-peers      loki-s3-integrator:status-peers        status_peers                 peer     
loki:grafana-dashboards-provider     grafana:grafana-dashboard              grafana_dashboard            regular  
loki:grafana-source                  grafana:grafana-source                 grafana_datasource           regular  
loki:logging                         otelcol:send-loki-logs                 loki_push_api                regular  
loki:loki-cluster                    loki-backend:loki-cluster              loki_cluster                 regular  
loki:loki-cluster                    loki-read:loki-cluster                 loki_cluster                 regular  
loki:loki-cluster                    loki-write:loki-cluster                loki_cluster                 regular  
loki:loki-peers                      loki:loki-peers                        loki_peers                   peer     
loki:self-metrics-endpoint           otelcol:metrics-endpoint               prometheus_scrape            regular  
loki:send-datasource                 tempo:receive-datasource               grafana_datasource_exchange  regular  
mimir-s3-integrator:s3-credentials   mimir:s3                               s3                           regular  
mimir-s3-integrator:status-peers     mimir-s3-integrator:status-peers       status_peers                 peer     
mimir:grafana-dashboards-provider    grafana:grafana-dashboard              grafana_dashboard            regular  
mimir:grafana-source                 grafana:grafana-source                 grafana_datasource           regular  
mimir:mimir-cluster                  mimir-backend:mimir-cluster            mimir_cluster                regular  
mimir:mimir-cluster                  mimir-read:mimir-cluster               mimir_cluster                regular  
mimir:mimir-cluster                  mimir-write:mimir-cluster              mimir_cluster                regular  
mimir:mimir-peers                    mimir:mimir-peers                      mimir_peers                  peer     
mimir:receive-remote-write           otelcol:send-remote-write              prometheus_remote_write      regular  
mimir:receive-remote-write           tempo:send-remote-write                prometheus_remote_write      regular  
mimir:self-metrics-endpoint          otelcol:metrics-endpoint               prometheus_scrape            regular  
mimir:send-datasource                tempo:receive-datasource               grafana_datasource_exchange  regular  
otelcol:grafana-dashboards-provider  grafana:grafana-dashboard              grafana_dashboard            regular  
otelcol:peers                        otelcol:peers                          otelcol_replica              peer     
otelcol:receive-loki-logs            alertmanager:logging                   loki_push_api                regular  
otelcol:receive-loki-logs            grafana:logging                        loki_push_api                regular  
otelcol:receive-loki-logs            loki:logging-consumer                  loki_push_api                regular  
otelcol:receive-loki-logs            mimir:logging-consumer                 loki_push_api                regular  
otelcol:receive-loki-logs            tempo:logging                          loki_push_api                regular  
otelcol:receive-traces               grafana:charm-tracing                  tracing                      regular  
otelcol:receive-traces               loki:charm-tracing                     tracing                      regular  
otelcol:receive-traces               mimir:charm-tracing                    tracing                      regular  
tempo-s3-integrator:s3-credentials   tempo:s3                               s3                           regular  
tempo-s3-integrator:status-peers     tempo-s3-integrator:status-peers       status_peers                 peer     
tempo:grafana-dashboard              grafana:grafana-dashboard              grafana_dashboard            regular  
tempo:grafana-source                 grafana:grafana-source                 grafana_datasource           regular  
tempo:metrics-endpoint               otelcol:metrics-endpoint               prometheus_scrape            regular  
tempo:peers                          tempo:peers                            tempo_peers                  peer     
tempo:tempo-cluster                  tempo-compactor:tempo-cluster          tempo_cluster                regular  
tempo:tempo-cluster                  tempo-distributor:tempo-cluster        tempo_cluster                regular  
tempo:tempo-cluster                  tempo-ingester:tempo-cluster           tempo_cluster                regular  
tempo:tempo-cluster                  tempo-metrics-generator:tempo-cluster  tempo_cluster                regular  
tempo:tempo-cluster                  tempo-querier:tempo-cluster            tempo_cluster                regular  
tempo:tempo-cluster                  tempo-query-frontend:tempo-cluster     tempo_cluster                regular  
tempo:tracing                        otelcol:send-traces                    tracing                      regular  
traefik:ingress                      grafana:ingress                        ingress                      regular  
traefik:ingress                      loki:ingress                           ingress                      regular  
traefik:ingress                      mimir:ingress                          ingress                      regular  
traefik:peers                        traefik:peers                          traefik_peers                peer     
traefik:traefik-route                otelcol:ingress                        traefik_route                regular
```

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
