### PR TITLE
refactor: Move otelcol checks to the TF charm module

### DIFF
--- a/terraform/cos/applications.tf
+++ b/terraform/cos/applications.tf
@@ -114,7 +114,7 @@ module "mimir" {
 }
 
 module "opentelemetry_collector" {
-  source = "git::https://github.com/canonical/opentelemetry-collector-k8s-operator//terraform"
+  source = "git::https://github.com/canonical/opentelemetry-collector-k8s-operator//terraform?ref=feat/tf-checks"
 
   app_name           = var.opentelemetry_collector.app_name
   channel            = local.channels.otelcol

--- a/terraform/cos/applications.tf
+++ b/terraform/cos/applications.tf
@@ -114,7 +114,7 @@ module "mimir" {
 }
 
 module "opentelemetry_collector" {
-  source = "git::https://github.com/canonical/opentelemetry-collector-k8s-operator//terraform?ref=feat/tf-checks"
+  source = "git::https://github.com/canonical/opentelemetry-collector-k8s-operator//terraform"
 
   app_name           = var.opentelemetry_collector.app_name
   channel            = local.channels.otelcol

--- a/terraform/cos/checks.tf
+++ b/terraform/cos/checks.tf
@@ -34,10 +34,3 @@ check "tempo_worker_ingester_storage_directives" {
     error_message = "tempo_worker.ingester_worker_storage_directives ${local.storage_directives_warning}"
   }
 }
-
-check "opentelemetry_collector_storage_directives" {
-  assert {
-    condition     = length(var.opentelemetry_collector.storage_directives) > 0
-    error_message = "opentelemetry_collector.storage_directives ${local.storage_directives_warning}"
-  }
-}

--- a/terraform/cos/tests/storage_directives.tftest.hcl
+++ b/terraform/cos/tests/storage_directives.tftest.hcl
@@ -99,21 +99,6 @@ run "warns_when_tempo_worker_ingester_storage_directives_unset" {
   ]
 }
 
-run "warns_when_opentelemetry_collector_storage_directives_unset" {
-  command = plan
-
-  variables {
-    grafana      = { storage_directives = { "foo" = "1G" } }
-    loki_worker  = { write_storage_directives = { "foo" = "1G" } }
-    mimir_worker = { write_storage_directives = { "foo" = "1G" }, backend_storage_directives = { "foo" = "1G" } }
-    tempo_worker = { ingester_worker_storage_directives = { "foo" = "1G" } }
-  }
-
-  expect_failures = [
-    check.opentelemetry_collector_storage_directives,
-  ]
-}
-
 run "no_warning_when_all_storage_directives_set" {
   command = plan
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Sometimes users want to deploy Otelcol standalone and do not get warned about setting the TF storage_directives.

## Solution
<!-- A summary of the solution addressing the above issue -->
In tandem with this PR:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/304

we moved the warning responsibilities to the charm module, out of the product module.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [x] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).
- [x] This PR has breaking changes to the product API(s) and I have created an issue in [SolQA pipelines](https://github.com/canonical/terragrunt-deployment-pipelines) to address this.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
COS Lite has no otelcol app so there is nothing to do there.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
### Unit tests
I had to update the opentelemetry-collector reference in `applications.tf` to `?ref=feat/tf-checks` and then run the unit tests, which pass:
```shell
observability-stack main ($!) .venv 
❯ just unit-test cos     
Upgrading modules...
Downloading git::https://github.com/canonical/opentelemetry-collector-k8s-operator?ref=feat/tf-checks for opentelemetry_collector...
# snip ...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
tests/conditional_ingress.tftest.hcl... in progress
  run "traefik_ingress_validates_conflicting_ingress"... pass
  run "traefik_ingress_enabled"... pass
  run "traefik_ingress_disabled"... pass
tests/conditional_ingress.tftest.hcl... tearing down
tests/conditional_ingress.tftest.hcl... pass
tests/external_tls.tftest.hcl... in progress
  run "external_cert_urls_both_null"... pass
  run "external_cert_urls_both_set"... pass
  run "external_certificates_offer_url_only_fails"... pass
  run "external_ca_cert_offer_url_only_fails"... pass
tests/external_tls.tftest.hcl... tearing down
tests/external_tls.tftest.hcl... pass
tests/grafana_database.tftest.hcl... in progress
  run "default_grafana_requires_database_offer"... pass
  run "grafana_conditionally_integrated_to_database_offer"... pass
  run "grafana_scale_1_integrated_to_database_offer"... pass
  run "grafana_scale_1_no_database_offer"... pass
tests/grafana_database.tftest.hcl... tearing down
tests/grafana_database.tftest.hcl... pass
tests/internal_tls.tftest.hcl... in progress
  run "internal_tls_enabled"... pass
  run "internal_tls_disabled"... pass
tests/internal_tls.tftest.hcl... tearing down
tests/internal_tls.tftest.hcl... pass
tests/model.tftest.hcl... in progress
  run "model_created_when_no_uuid"... pass
  run "model_created_with_full_inputs"... pass
  run "model_attached_when_uuid_provided"... pass
  run "model_invalid_uuid_rejected"... pass
  run "model_uuid_with_cloud_rejected"... pass
  run "model_uuid_with_constraints_rejected"... pass
  run "model_uuid_with_annotations_rejected"... pass
  run "model_empty_name_when_creating_rejected"... pass
tests/model.tftest.hcl... tearing down
tests/model.tftest.hcl... pass
tests/revision_pin.tftest.hcl... in progress
  run "user_revision_pin_is_respected"... pass
  run "no_pin_uses_datasource"... pass
tests/revision_pin.tftest.hcl... tearing down
tests/revision_pin.tftest.hcl... pass
tests/storage_directives.tftest.hcl... in progress
  run "warns_when_grafana_storage_directives_unset_and_database_disabled"... pass
  run "no_warning_when_grafana_storage_unset_but_database_enabled"... pass
  run "warns_when_loki_worker_write_storage_directives_unset"... pass
  run "warns_when_mimir_worker_write_storage_directives_unset"... pass
  run "warns_when_mimir_worker_backend_storage_directives_unset"... pass
  run "warns_when_tempo_worker_ingester_storage_directives_unset"... pass
  run "no_warning_when_all_storage_directives_set"... pass
tests/storage_directives.tftest.hcl... tearing down
tests/storage_directives.tftest.hcl... pass

Success! 30 passed, 0 failed.
```

### The root module
Using atelier to setup COS from this commit:
- `dacaf7cbaa27c480903566011185487d916126a4`

which references the otelcol charm module in the tandem PR.

```shell
atelier module add https://github.com/canonical/observability-stack.git --module terraform/cos --ref dacaf7cbaa27c480903566011185487d916126a4
```
```shell
terraform plan

Plan: 102 to add, 0 to change, 0 to destroy.
╷
│ Warning: Check block assertion failed
│ 
│   on .terraform/modules/cos.opentelemetry_collector/terraform/main.tf line 20, in check "storage_directives":
│   20:     condition     = length(var.storage_directives) > 0
│     ├────────────────
│     │ var.storage_directives is empty map of string
│ 
│ storage_directives is unset, so it will use the default 1G volume. Set a size before deploying to production; resizing a persistent volume after deployment requires manual steps. See
│ https://documentation.ubuntu.com/observability/latest/how-to/configure-and-tune/customize-storage-options/
╵
╷
│ Warning: Check block assertion failed
│ 
│   on .terraform/modules/cos/terraform/cos/checks.tf line 5, in check "grafana_storage_directives":
│    5:     condition     = local.grafana_db_enabled || length(var.grafana.storage_directives) > 0
│     ├────────────────
│     │ local.grafana_db_enabled is false
│     │ var.grafana.storage_directives is empty map of string
│ 
│ grafana.storage_directives is unset, so it will use the default 1G volume. Set a size before deploying to production; resizing a persistent volume after deployment requires manual steps. See
│ https://documentation.ubuntu.com/observability/latest/how-to/configure-and-tune/customize-storage-options/
╵
╷
│ Warning: Check block assertion failed
│ 
│   on .terraform/modules/cos/terraform/cos/checks.tf line 12, in check "loki_worker_write_storage_directives":
│   12:     condition     = length(var.loki_worker.write_storage_directives) > 0
│     ├────────────────
│     │ var.loki_worker.write_storage_directives is empty map of string
│ 
│ loki_worker.write_storage_directives is unset, so it will use the default 1G volume. Set a size before deploying to production; resizing a persistent volume after deployment requires manual steps. See
│ https://documentation.ubuntu.com/observability/latest/how-to/configure-and-tune/customize-storage-options/
╵
╷
│ Warning: Check block assertion failed
│ 
│   on .terraform/modules/cos/terraform/cos/checks.tf line 19, in check "mimir_worker_write_storage_directives":
│   19:     condition     = length(var.mimir_worker.write_storage_directives) > 0
│     ├────────────────
│     │ var.mimir_worker.write_storage_directives is empty map of string
│ 
│ mimir_worker.write_storage_directives is unset, so it will use the default 1G volume. Set a size before deploying to production; resizing a persistent volume after deployment requires manual steps. See
│ https://documentation.ubuntu.com/observability/latest/how-to/configure-and-tune/customize-storage-options/
╵
╷
│ Warning: Check block assertion failed
│ 
│   on .terraform/modules/cos/terraform/cos/checks.tf line 26, in check "mimir_worker_backend_storage_directives":
│   26:     condition     = length(var.mimir_worker.backend_storage_directives) > 0
│     ├────────────────
│     │ var.mimir_worker.backend_storage_directives is empty map of string
│ 
│ mimir_worker.backend_storage_directives is unset, so it will use the default 1G volume. Set a size before deploying to production; resizing a persistent volume after deployment requires manual steps. See
│ https://documentation.ubuntu.com/observability/latest/how-to/configure-and-tune/customize-storage-options/
╵
╷
│ Warning: Check block assertion failed
│ 
│   on .terraform/modules/cos/terraform/cos/checks.tf line 33, in check "tempo_worker_ingester_storage_directives":
│   33:     condition     = length(var.tempo_worker.ingester_worker_storage_directives) > 0
│     ├────────────────
│     │ var.tempo_worker.ingester_worker_storage_directives is empty map of string
│ 
│ tempo_worker.ingester_worker_storage_directives is unset, so it will use the default 1G volume. Set a size before deploying to production; resizing a persistent volume after deployment requires manual steps. See
│ https://documentation.ubuntu.com/observability/latest/how-to/configure-and-tune/customize-storage-options/
```


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
