### PR TITLE
feat(docs): migrate cos-config docs from discourse

### DIFF
--- a/docs/how-to/integrate/index.md
+++ b/docs/how-to/integrate/index.md
@@ -36,6 +36,7 @@ Manually enable a Tempo HA tracing receiver <manually-enable-tempo-ha-tracing-re
 Add alert rules <adding-alert-rules>
 Integrate Alertmanager with external receivers <integrate-alertmanager-receivers>
 Set up SLOs with Sloth <set-up-slos-with-sloth>
+Sync alert rules from a git repo <sync-alert-rules-from-git-repo>
 ```
 
 ## Test & validate integrations

--- a/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
+++ b/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
@@ -1,0 +1,215 @@
+# Sync alert rules from a git repo using the cos-configuration charm
+
+Imagine your business is looking to migrate your observability solution to COS Lite, but that you already have a lot of time invested into converting operational knowledge into alert rules that you're versioning in a git repository.
+
+In this tutorial you will learn how to make COS Lite automatically sync the alert rules of your git repo to Prometheus using the [COS Configuration charm](https://charmhub.io/cos-configuration-k8s/docs).
+
+## Prerequisites
+
+This tutorial assumes that you already have the following:
+
+- a Kubernetes deployment [bootstrapped with Juju](https://juju.is/docs/olm/get-started-with-juju#heading--prepare-your-cloud).
+- a git repo with your Prometheus Alert rules.
+
+## Create a juju model
+
+In the following Juju model we will deploy our applications
+
+```shell
+juju add-model cos
+```
+
+Now, you can check that our model is empty and ready:
+
+```shell
+$ juju status
+
+Model  Controller           Cloud/Region        Version  SLA          Timestamp
+cos    charm-dev-batteries  microk8s/localhost  3.0.3    unsupported  17:21:00-03:00
+
+Model "admin/cos" is empty.
+```
+
+## Deploy Prometheus Charmed Operator
+
+```
+$ juju deploy prometheus-k8s prometheus --channel stable
+```
+
+After a few seconds, our Prometheus application is up and running:
+
+```shell
+$ juju status --relations
+
+Model  Controller           Cloud/Region        Version  SLA          Timestamp
+cos    charm-dev-batteries  microk8s/localhost  3.0.3    unsupported  17:26:56-03:00
+
+App         Version  Status  Scale  Charm           Channel  Rev  Address         Exposed  Message
+prometheus  2.33.5   active      1  prometheus-k8s  stable   103  10.152.183.235  no
+
+Unit           Workload  Agent  Address      Ports  Message
+prometheus/0*  active    idle   10.1.36.122
+
+Relation provider            Requirer                     Interface         Type  Message
+prometheus:prometheus-peers  prometheus:prometheus-peers  prometheus_peers  peer
+```
+
+## Deploy COS configuration Charmed Operator
+
+When deploying this charm, we will also need to provide some configuration:
+
+- `git_repo`: URL to repo to clone and sync against.
+- `git_branch`: The git branch to check out.
+- `git_depth`: Cloning depth, to truncate commit history to the specified number of commits. Zero means no truncating.
+- `prometheus_alert_rules_path`: Relative path in repo to prometheus rules.
+
+Now, let's deploy it:
+
+```shell
+$ juju deploy cos-configuration-k8s cos-config \
+    --config git_repo=https://github.com/Abuelodelanada/cos-config \
+    --config git_branch=main \
+    --config git_depth=1 \
+    --config prometheus_alert_rules_path=rules/prod/prometheus/
+```
+
+At this moment, our model looks like this:
+
+```shell
+$ juju status --relations
+
+Model  Controller           Cloud/Region        Version  SLA          Timestamp
+cos    charm-dev-batteries  microk8s/localhost  3.0.3    unsupported  17:43:03-03:00
+
+App         Version  Status  Scale  Charm                  Channel  Rev  Address         Exposed  Message
+cos-config  3.5.0    active      1  cos-configuration-k8s  stable    15  10.152.183.147  no
+prometheus  2.33.5   active      1  prometheus-k8s         stable   103  10.152.183.235  no
+
+Unit           Workload  Agent  Address      Ports  Message
+cos-config/0*  active    idle   10.1.36.124
+prometheus/0*  active    idle   10.1.36.122
+
+Relation provider            Requirer                     Interface                  Type  Message
+cos-config:replicas          cos-config:replicas          cos_configuration_replica  peer
+prometheus:prometheus-peers  prometheus:prometheus-peers  prometheus_peers           peer
+```
+
+## Relate Prometheus to COS Configuration
+
+Once we execute this command:
+
+```shell
+$ juju relate prometheus cos-config
+```
+
+we will get both charms related:
+
+```shell
+$ juju status --relations
+Model  Controller           Cloud/Region        Version  SLA          Timestamp
+cos    charm-dev-batteries  microk8s/localhost  3.0.3    unsupported  17:51:33-03:00
+
+App         Version  Status  Scale  Charm                  Channel  Rev  Address         Exposed  Message
+cos-config  3.5.0    active      1  cos-configuration-k8s  stable    15  10.152.183.147  no
+prometheus  2.33.5   active      1  prometheus-k8s         stable   103  10.152.183.235  no
+
+Unit           Workload  Agent  Address      Ports  Message
+cos-config/0*  active    idle   10.1.36.124
+prometheus/0*  active    idle   10.1.36.122
+
+Relation provider             Requirer                     Interface                  Type     Message
+cos-config:prometheus-config  prometheus:metrics-endpoint  prometheus_scrape          regular
+cos-config:replicas           cos-config:replicas          cos_configuration_replica  peer
+prometheus:prometheus-peers   prometheus:prometheus-peers  prometheus_peers           peer
+```
+
+## Verification
+
+After setting the `git_repo` (and optionally `git_branch`), the contents should be present in the workload container,
+
+```shell
+$ juju ssh --container git-sync cos-config/0  ls -l /git
+
+total 4
+drwxr-xr-x 3 root root 4096 Feb 23 20:40 dd2cc335a9b5734e0adbb25681074b09a4c3a111
+lrwxrwxrwx 1 root root   40 Feb 23 20:40 repo -> dd2cc335a9b5734e0adbb25681074b09a4c3a111
+```
+
+and accessible from the charm container
+
+```shell
+$ juju ssh cos-config/0 ls -l /var/lib/juju/storage/content-from-git/0
+
+total 4
+drwxr-xr-x 3 root root 4096 Feb 23 20:40 dd2cc335a9b5734e0adbb25681074b09a4c3a111
+lrwxrwxrwx 1 root root   40 Feb 23 20:40 repo -> dd2cc335a9b5734e0adbb25681074b09a4c3a111
+```
+
+After relating to e.g. prometheus, rules from the synced repo should appear in app data,
+
+```shell
+$ juju show-unit prometheus/0 \
+    --format json \
+    | jq '."prometheus/0"."relation-info"'
+
+[
+  {
+    "relation-id": 0,
+    "endpoint": "prometheus-peers",
+    "related-endpoint": "prometheus-peers",
+    "application-data": {},
+    "local-unit": {
+      "in-scope": true,
+      "data": {
+        "egress-subnets": "10.152.183.235/32",
+        "ingress-address": "10.152.183.235",
+        "private-address": "10.152.183.235"
+      }
+    }
+  },
+  {
+    "relation-id": 2,
+    "endpoint": "metrics-endpoint",
+    "related-endpoint": "prometheus-config",
+    "application-data": {
+      "alert_rules": "{\"groups\": [{\"name\": \"zinc_missing_alerts\", \"rules\": [{\"alert\": \"PepeTargetMissingRemote\", \"annotations\": {\"description\": \"A Prometheus target has disappeared. An exporter might be crashed.\\n  VALUE = {{ $value }}\\n  LABELS = {{ $labels }}\", \"summary\": \"Prometheus target missing (instance {{ $labels.instance }})\"}, \"expr\": \"up{juju_application=\\\"PepeApp\\\"} == 0\", \"for\": \"0m\", \"labels\": {\"gitbranch\": \"main\", \"origin\": \"github\", \"severity\": \"critical\"}}]}]}"
+...
+```
+
+as well as in prometheus itself using the command line:
+
+```shell
+$ juju ssh prometheus/0 curl localhost:9090/api/v1/rules
+
+{"status":"success","data":{"groups":[{"name":"zinc_missing_alerts","file":"/etc/prometheus/rules/juju_zinc_missing_alerts.rules","rules":[{"state":"inactive","name":"PepeTargetMissingRemote","query":"up{juju_application=\"PepeApp\"} == 0","duration":0,"labels":{"gitbranch":"main","origin":"github","severity":"critical"},"annotations":{"description":"A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}","summary":"Prometheus target missing (instance {{ $labels.instance }})"},"alerts":[],"health":"ok","evaluationTime":0.000263312,"lastEvaluation":"2023-02-23T20:55:06.506298391Z","type":"alerting"}],"interval":60,"limit":0,"evaluationTime":0.000272579,"lastEvaluation":"2023-02-23T20:55:06.50629195Z"}]}}
+```
+
+## Sync interval
+
+The repo syncs on every [`update-status` event](https://juju.is/docs/sdk/update-status-event) or when the juju administrator manually runs the `sync-now` action.
+
+```shell
+$ juju run cos-config/0 sync-now
+Running operation 1 with 1 task
+  - task 2 on unit-cos-config-0
+
+Waiting for task 2...
+18:10:28 Calling git-sync with --one-time...
+18:10:29 Warning: I0223 21:10:28.544402     186 main.go:473] "level"=0 "msg"="starting up" "pid"=186 "args"=["/git-sync","--repo","https://github.com/Abuelodelanada/cos-config","--branch","main","--rev","HEAD","--depth","1","--root","/git","--dest","repo","--one-time"]
+
+git-sync-stdout: ""
+```
+
+## Extra information
+
+COS Configuration Charmed Operator not only can forward alert rules to Prometheus, but also alert rules to Loki and Dashboards to Grafana.
+
+Paths to Loki alert rules and Grafana dashboard files, can also be set after deployment:
+
+```shell
+$ juju config cos-config loki_alert_rules_path=rules/prod/loki/
+$ juju relate cos-config loki-k8s
+
+$ juju config cos-config grafana_dashboards_path=dashboards/prod/grafana/
+$ juju relate cos-config grafana-k8s
+```

--- a/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
+++ b/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to sync alert rules and dashboards from a git repository using the cos-configuration-k8s charm."
+---
+
 # Sync alert rules from a git repo using the cos-configuration charm
 
 Imagine your business is looking to migrate your observability solution to COS Lite, but that you already have a lot of time invested into converting operational knowledge into alert rules that you're versioning in a git repository.

--- a/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
+++ b/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
@@ -10,7 +10,7 @@ This guide shows how to sync Prometheus alert rules from a git repository into y
 
 ## Prerequisites
 
-- A Kubernetes deployment [bootstrapped with Juju](https://juju.is/docs/olm/get-started-with-juju#heading--prepare-your-cloud).
+- A Kubernetes deployment [bootstrapped with Juju](https://canonical.com/juju/docs/juju-cli/3.6/tutorial/).
 - A git repository containing your Prometheus alert rules.
 
 ## Create a model

--- a/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
+++ b/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
@@ -4,28 +4,24 @@ myst:
     description: "Learn how to sync alert rules and dashboards from a git repository using the cos-configuration-k8s charm."
 ---
 
-# Sync alert rules from a git repo using the cos-configuration charm
+# Sync alert rules from a git repo
 
-Imagine your business is looking to migrate your observability solution to COS Lite, but that you already have a lot of time invested into converting operational knowledge into alert rules that you're versioning in a git repository.
-
-In this tutorial you will learn how to make COS Lite automatically sync the alert rules of your git repo to Prometheus using the [COS Configuration charm](https://charmhub.io/cos-configuration-k8s/docs).
+This guide shows how to sync Prometheus alert rules from a git repository into your COS deployment using the [cos-configuration-k8s](https://charmhub.io/cos-configuration-k8s/docs) charm. The same approach works for Loki alert rules and Grafana dashboards.
 
 ## Prerequisites
 
-This tutorial assumes that you already have the following:
+- A Kubernetes deployment [bootstrapped with Juju](https://juju.is/docs/olm/get-started-with-juju#heading--prepare-your-cloud).
+- A git repository containing your Prometheus alert rules.
 
-- a Kubernetes deployment [bootstrapped with Juju](https://juju.is/docs/olm/get-started-with-juju#heading--prepare-your-cloud).
-- a git repo with your Prometheus Alert rules.
+## Create a model
 
-## Create a juju model
-
-In the following Juju model we will deploy our applications
+Add a model to host the deployment:
 
 ```shell
 juju add-model cos
 ```
 
-Now, you can check that our model is empty and ready:
+Confirm the model is empty and ready:
 
 ```shell
 $ juju status
@@ -36,13 +32,15 @@ cos    charm-dev-batteries  microk8s/localhost  3.0.3    unsupported  17:21:00-0
 Model "admin/cos" is empty.
 ```
 
-## Deploy Prometheus Charmed Operator
+## Deploy Prometheus
+
+Deploy Prometheus from the stable channel:
 
 ```
 $ juju deploy prometheus-k8s prometheus --channel stable
 ```
 
-After a few seconds, our Prometheus application is up and running:
+After a few seconds, Prometheus is up and running:
 
 ```shell
 $ juju status --relations
@@ -60,16 +58,16 @@ Relation provider            Requirer                     Interface         Type
 prometheus:prometheus-peers  prometheus:prometheus-peers  prometheus_peers  peer
 ```
 
-## Deploy COS configuration Charmed Operator
+## Deploy cos-configuration
 
-When deploying this charm, we will also need to provide some configuration:
+The cos-configuration charm requires the following configuration options:
 
-- `git_repo`: URL to repo to clone and sync against.
+- `git_repo`: URL of the git repository to clone and sync.
 - `git_branch`: The git branch to check out.
-- `git_depth`: Cloning depth, to truncate commit history to the specified number of commits. Zero means no truncating.
-- `prometheus_alert_rules_path`: Relative path in repo to prometheus rules.
+- `git_depth`: Cloning depth, to truncate commit history to the specified number of commits. Zero means no truncation.
+- `prometheus_alert_rules_path`: Relative path in the repo to Prometheus rules.
 
-Now, let's deploy it:
+Deploy the charm with your configuration:
 
 ```shell
 $ juju deploy cos-configuration-k8s cos-config \
@@ -79,7 +77,7 @@ $ juju deploy cos-configuration-k8s cos-config \
     --config prometheus_alert_rules_path=rules/prod/prometheus/
 ```
 
-At this moment, our model looks like this:
+The model now looks like this:
 
 ```shell
 $ juju status --relations
@@ -100,15 +98,15 @@ cos-config:replicas          cos-config:replicas          cos_configuration_repl
 prometheus:prometheus-peers  prometheus:prometheus-peers  prometheus_peers           peer
 ```
 
-## Relate Prometheus to COS Configuration
+## Integrate with Prometheus
 
-Once we execute this command:
+Relate Prometheus to cos-configuration so it can pick up the alert rules:
 
 ```shell
 $ juju relate prometheus cos-config
 ```
 
-we will get both charms related:
+Confirm the relation is established:
 
 ```shell
 $ juju status --relations
@@ -129,9 +127,9 @@ cos-config:replicas           cos-config:replicas          cos_configuration_rep
 prometheus:prometheus-peers   prometheus:prometheus-peers  prometheus_peers           peer
 ```
 
-## Verification
+## Verify the sync
 
-After setting the `git_repo` (and optionally `git_branch`), the contents should be present in the workload container,
+Check that the repository contents are present in the workload container:
 
 ```shell
 $ juju ssh --container git-sync cos-config/0  ls -l /git
@@ -141,7 +139,7 @@ drwxr-xr-x 3 root root 4096 Feb 23 20:40 dd2cc335a9b5734e0adbb25681074b09a4c3a11
 lrwxrwxrwx 1 root root   40 Feb 23 20:40 repo -> dd2cc335a9b5734e0adbb25681074b09a4c3a111
 ```
 
-and accessible from the charm container
+They are also accessible from the charm container:
 
 ```shell
 $ juju ssh cos-config/0 ls -l /var/lib/juju/storage/content-from-git/0
@@ -151,7 +149,7 @@ drwxr-xr-x 3 root root 4096 Feb 23 20:40 dd2cc335a9b5734e0adbb25681074b09a4c3a11
 lrwxrwxrwx 1 root root   40 Feb 23 20:40 repo -> dd2cc335a9b5734e0adbb25681074b09a4c3a111
 ```
 
-After relating to e.g. prometheus, rules from the synced repo should appear in app data,
+After relating to Prometheus, the synced rules appear in application data:
 
 ```shell
 $ juju show-unit prometheus/0 \
@@ -182,7 +180,7 @@ $ juju show-unit prometheus/0 \
 ...
 ```
 
-as well as in prometheus itself using the command line:
+They also appear in the Prometheus rules API:
 
 ```shell
 $ juju ssh prometheus/0 curl localhost:9090/api/v1/rules
@@ -192,7 +190,7 @@ $ juju ssh prometheus/0 curl localhost:9090/api/v1/rules
 
 ## Sync interval
 
-The repo syncs on every [`update-status` event](https://juju.is/docs/sdk/update-status-event) or when the juju administrator manually runs the `sync-now` action.
+The repository syncs automatically on every [`update-status` event](https://juju.is/docs/sdk/update-status-event). To trigger a sync manually, run the `sync-now` action:
 
 ```shell
 $ juju run cos-config/0 sync-now
@@ -206,11 +204,9 @@ Waiting for task 2...
 git-sync-stdout: ""
 ```
 
-## Extra information
+## Sync Loki rules and Grafana dashboards
 
-COS Configuration Charmed Operator not only can forward alert rules to Prometheus, but also alert rules to Loki and Dashboards to Grafana.
-
-Paths to Loki alert rules and Grafana dashboard files, can also be set after deployment:
+The cos-configuration charm can also sync Loki alert rules and Grafana dashboards. Set the paths and relate the corresponding charms:
 
 ```shell
 $ juju config cos-config loki_alert_rules_path=rules/prod/loki/

--- a/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
+++ b/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
@@ -37,8 +37,6 @@ Model "admin/cos" is empty.
 Deploy Prometheus from the stable channel:
 
 ```
-$ juju deploy prometheus-k8s prometheus --channel stable
-```
 
 After a few seconds, Prometheus is up and running:
 
@@ -70,7 +68,7 @@ The cos-configuration charm requires the following configuration options:
 Deploy the charm with your configuration:
 
 ```shell
-$ juju deploy cos-configuration-k8s cos-config \
+juju deploy cos-configuration-k8s cos-config \
     --config git_repo=https://github.com/Abuelodelanada/cos-config \
     --config git_branch=main \
     --config git_depth=1 \
@@ -103,7 +101,7 @@ prometheus:prometheus-peers  prometheus:prometheus-peers  prometheus_peers      
 Relate Prometheus to cos-configuration so it can pick up the alert rules:
 
 ```shell
-$ juju relate prometheus cos-config
+juju relate prometheus cos-config
 ```
 
 Confirm the relation is established:
@@ -209,9 +207,9 @@ git-sync-stdout: ""
 The cos-configuration charm can also sync Loki alert rules and Grafana dashboards. Set the paths and relate the corresponding charms:
 
 ```shell
-$ juju config cos-config loki_alert_rules_path=rules/prod/loki/
-$ juju relate cos-config loki-k8s
+juju config cos-config loki_alert_rules_path=rules/prod/loki/
+juju relate cos-config loki-k8s
 
-$ juju config cos-config grafana_dashboards_path=dashboards/prod/grafana/
-$ juju relate cos-config grafana-k8s
+juju config cos-config grafana_dashboards_path=dashboards/prod/grafana/
+juju relate cos-config grafana-k8s
 ```

--- a/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
+++ b/docs/how-to/integrate/sync-alert-rules-from-git-repo.md
@@ -4,7 +4,7 @@ myst:
     description: "Learn how to sync alert rules and dashboards from a git repository using the cos-configuration-k8s charm."
 ---
 
-# Sync alert rules from a git repo
+# Sync alert rules from a git repository
 
 This guide shows how to sync Prometheus alert rules from a git repository into your COS deployment using the [cos-configuration-k8s](https://charmhub.io/cos-configuration-k8s/docs) charm. The same approach works for Loki alert rules and Grafana dashboards.
 
@@ -65,7 +65,7 @@ The cos-configuration charm requires the following configuration options:
 - `git_repo`: URL of the git repository to clone and sync.
 - `git_branch`: The git branch to check out.
 - `git_depth`: Cloning depth, to truncate commit history to the specified number of commits. Zero means no truncation.
-- `prometheus_alert_rules_path`: Relative path in the repo to Prometheus rules.
+- `prometheus_alert_rules_path`: Relative path in the repository to Prometheus rules.
 
 Deploy the charm with your configuration:
 


### PR DESCRIPTION
This PR migrates cos-config docs from [discourse](https://discourse.charmhub.io/t/cos-configuration-k8s-docs-index/7284) to sphinx.

- [Sync alert rules from a git repo using the cos-configuration charm](https://discourse.charmhub.io/t/sync-alert-rules-from-a-git-repo-using-the-cos-configuration-charm/8793) (authored by @Abuelodelanada).

Addresses:
- https://github.com/canonical/charmhub-listing-review/issues/90