### PR TITLE
feat: Scoped solution tests

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -78,8 +78,6 @@ jobs:
               - '.github/workflows/_integration.yml'
               - 'tests/integration/conftest.py'
               - 'tests/integration/helpers.py'
-              - 'pyproject.toml'
-              - 'uv.lock'
             cos:
               - *shared
               - 'terraform/cos/**'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -63,6 +63,7 @@ jobs:
     outputs:
       cos: ${{ steps.filter.outputs.cos }}
       cos_lite: ${{ steps.filter.outputs.cos_lite }}
+      cos_dev: ${{ steps.filter.outputs.cos_dev }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -87,6 +88,10 @@ jobs:
               - *shared
               - 'terraform/cos-lite/**'
               - 'tests/integration/cos_lite/**'
+            cos_dev:
+              - *shared
+              - 'terraform/cos-dev/**'
+              - 'tests/integration/cos_dev/**'
   test-integration-cos-lite:
     name: COS Lite Terraform integration
     needs: [test-unit, changes]
@@ -103,3 +108,11 @@ jobs:
     with:
       product: cos
       runner: self-hosted-linux-amd64-noble-xlarge
+  test-integration-cos-dev:
+    name: COS Dev Terraform integration
+    needs: [test-unit, changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.cos_dev == 'true' }}
+    uses: canonical/observability-stack/.github/workflows/_integration.yml@main
+    with:
+      product: cos_dev
+      runner: self-hosted-linux-amd64-noble-large

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -57,24 +57,49 @@ jobs:
           sudo snap install just --classic
       - name: Unit test the Terraform modules
         run: just unit
+  changes:
+    name: Detect changed products
+    runs-on: ubuntu-latest
+    outputs:
+      cos: ${{ steps.filter.outputs.cos }}
+      cos_lite: ${{ steps.filter.outputs.cos_lite }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Filter changed paths per product
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            # Shared paths affect *both* products, so they trigger both suites
+            shared: &shared
+              - '.github/workflows/terraform.yml'
+              - '.github/workflows/_integration.yml'
+              - 'tests/integration/conftest.py'
+              - 'tests/integration/helpers.py'
+              - 'pyproject.toml'
+              - 'uv.lock'
+            cos:
+              - *shared
+              - 'terraform/cos/**'
+              - 'tests/integration/cos/**'
+            cos_lite:
+              - *shared
+              - 'terraform/cos-lite/**'
+              - 'tests/integration/cos_lite/**'
   test-integration-cos-lite:
     name: COS Lite Terraform integration
-    needs: [test-unit]
+    needs: [test-unit, changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.cos_lite == 'true' }}
     uses: canonical/observability-stack/.github/workflows/_integration.yml@main
     with:
       product: cos_lite
       runner: self-hosted-linux-amd64-noble-large
   test-integration-cos:
     name: COS Terraform integration
-    needs: [test-unit]
+    needs: [test-unit, changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.cos == 'true' }}
     uses: canonical/observability-stack/.github/workflows/_integration.yml@main
     with:
       product: cos
       runner: self-hosted-linux-amd64-noble-xlarge
-  test-integration-cos-dev:
-    name: COS Dev Terraform integration
-    needs: [test-unit]
-    uses: canonical/observability-stack/.github/workflows/_integration.yml@main
-    with:
-      product: cos_dev
-      runner: self-hosted-linux-amd64-noble-large


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/observability-stack/issues/454

## Solution
<!-- A summary of the solution addressing the above issue -->
This uses https://github.com/dorny/paths-filter to determine which product has changed. This project is mature, but we could replace this with bash logic if we want. This change features:
- Each product only triggers its own solution tests
	- E.g., COS Lite changes will not trigger COS or COS Dev solution tests.
- In addition to the TF changes per product, we want to run solution tests for all products on changes to:
	- '.github/workflows/terraform.yml'
	- '.github/workflows/_integration.yml'
	- 'tests/integration/conftest.py'
	- 'tests/integration/helpers.py'
- Manually triggering the solution tests, runs all.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [ ] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).
- [ ] This PR has breaking changes to the product API(s) and I have created an issue in [SolQA pipelines](https://github.com/canonical/terragrunt-deployment-pipelines) to address this.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This requires a backport to `track/3.0`

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
