### PR TITLE
feat(track/3.0): Scoped solution tests

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -57,16 +57,46 @@ jobs:
           sudo snap install just --classic
       - name: Unit test the Terraform modules
         run: just unit
+  changes:
+    name: Detect changed products
+    runs-on: ubuntu-latest
+    outputs:
+      cos: ${{ steps.filter.outputs.cos }}
+      cos_lite: ${{ steps.filter.outputs.cos_lite }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Filter changed paths per product
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            # Shared paths affect *both* products, so they trigger both suites
+            shared: &shared
+              - '.github/workflows/terraform.yml'
+              - '.github/workflows/_integration.yml'
+              - 'tests/integration/conftest.py'
+              - 'tests/integration/helpers.py'
+            cos:
+              - *shared
+              - 'terraform/cos/**'
+              - 'tests/integration/cos/**'
+            cos_lite:
+              - *shared
+              - 'terraform/cos-lite/**'
+              - 'tests/integration/cos_lite/**'
   test-integration-cos-lite:
     name: COS Lite Terraform integration
-    needs: [test-unit]
+    needs: [test-unit, changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.cos_lite == 'true' }}
     uses: canonical/observability-stack/.github/workflows/_integration.yml@main
     with:
       product: cos_lite
       runner: self-hosted-linux-amd64-noble-large
   test-integration-cos:
     name: COS Terraform integration
-    needs: [test-unit]
+    needs: [test-unit, changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.cos == 'true' }}
     uses: canonical/observability-stack/.github/workflows/_integration.yml@main
     with:
       product: cos


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/observability-stack/issues/454

Backport of this PR:
- https://github.com/canonical/observability-stack/pull/455

but into track/3.0.

## Solution
<!-- A summary of the solution addressing the above issue -->
The only difference in this backport is that no COS Dev product exists on track/3.0 so it was removed from the cherry-pick.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [ ] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).
- [ ] This PR has breaking changes to the product API(s) and I have created an issue in [SolQA pipelines](https://github.com/canonical/terragrunt-deployment-pipelines) to address this.
