### PR TITLE
feat: Otelcol charm tracing integration

### DIFF
--- a/terraform/cos/integrations.tf
+++ b/terraform/cos/integrations.tf
@@ -306,7 +306,7 @@ resource "juju_integration" "charm_tracing_otelcol" {
 
   application {
     name     = module.tempo.app_names.tempo_coordinator
-    endpoint = module.tempo.provides.charm_tracing
+    endpoint = module.tempo.provides.tracing
   }
 
   application {

--- a/terraform/cos/integrations.tf
+++ b/terraform/cos/integrations.tf
@@ -301,6 +301,20 @@ resource "juju_integration" "charm_tracing_grafana" {
   lifecycle { replace_triggered_by = [terraform_data.grafana_litestream_resource] }
 }
 
+resource "juju_integration" "charm_tracing_otelcol" {
+  model_uuid = local.model_uuid
+
+  application {
+    name     = module.tempo.app_names.tempo_coordinator
+    endpoint = module.tempo.provides.charm_tracing
+  }
+
+  application {
+    name     = module.opentelemetry_collector.app_name
+    endpoint = module.opentelemetry_collector.requires.send_charm_traces
+  }
+}
+
 resource "juju_integration" "tempo_tracing_otelcol_tracing" {
   model_uuid = local.model_uuid
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We want to be able to check the charm traces of otelcol to check for charm performance bottlenecks.

## Solution
<!-- A summary of the solution addressing the above issue -->
Integrate with Tempo over both: workload and charm traces.

### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [ ] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).
- [ ] This PR has breaking changes to the product API(s) and I have created an issue in [SolQA pipelines](https://github.com/canonical/terragrunt-deployment-pipelines) to address this.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
