### PR TITLE
ci: add test scenarios for juju beta channels

### DIFF
--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        juju-channel: ["3.6/stable", "4.0/beta", "4.1/beta"]
+        juju-channel: ["3.6/stable"]
         scenario: ["tls_full", "tls_external", "tls_internal", "tls_none"]
         include:
         - juju-channel: "4.0/beta"

--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -38,8 +38,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        juju-channel: ["3.6/stable"]
+        juju-channel: ["3.6/stable", "4.0/beta", "4.1/beta"]
         scenario: ["tls_full", "tls_external", "tls_internal", "tls_none"]
+        include:
+        - juju-channel: "4.0/beta"
+          scenario: "tls_full"
+        - juju-channel: "4.1/beta"
+          scenario: "tls_full"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds Juju 4.0 and 4.1 beta channels to the strategy matrix of the integration tests.
To minimize total runtime, the beta channels are tested only with one scenario.