### PR TITLE
fix: Solution test on pytest-only changes

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - "**/*.tf"
+      - "tests/integration/**"
 
 jobs:
   lint-terraform:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We want to run our integration tests if there are only pytest changes. And this is a backport from this PR:
- https://github.com/canonical/observability-stack/pull/465/

### Checklist
- [ ] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [ ] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).
- [ ] This PR has breaking changes to the product API(s) and I have created an issue in [SolQA pipelines](https://github.com/canonical/terragrunt-deployment-pipelines) to address this.