### PR TITLE
fix(track/3.0): Juju v4 solution tests

### DIFF
--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -157,4 +157,16 @@ jobs:
             export S3_ACCESS_KEY=access-key
             export S3_SECRET_KEY=secret-key
           fi
-          just integration ${{ inputs.product }}/${{ matrix.scenario }}
+          if [[ "${{ runner.debug }}" == "1" ]]; then
+            export KEEP_MODELS=true
+            just integration ${{ inputs.product }}/${{ matrix.scenario }} --keep-models
+          else
+            just integration ${{ inputs.product }}/${{ matrix.scenario }}
+          fi
+
+      - name: Open SSH session on failure
+        if: ${{ failure() && (runner.debug == '1') }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          timeout-minutes: 30
+          limit-access-to-actor: true

--- a/justfile
+++ b/justfile
@@ -72,4 +72,4 @@ unit-test module:
 [group("Integration")]
 [working-directory("./tests/integration")]
 integration *args='':
-  uv run ${uv_flags} pytest -vv -ra --capture=no --exitfirst "${args}"
+  uv run ${uv_flags} pytest -vv -ra --capture=no --exitfirst {{args}}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,17 +10,31 @@ import pytest
 from helpers import TfDirManager
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--keep-models",
+        action="store_true",
+        default=False,
+        help="Keep temporarily-created models instead of destroying them after the tests run.",
+    )
+
+
+def _keep_models(request) -> bool:
+    """Whether to keep temporary models, via CLI flag or the KEEP_MODELS env var."""
+    return bool(request.config.getoption("--keep-models")) or (
+        os.environ.get("KEEP_MODELS") is not None
+    )
+
+
 @pytest.fixture(scope="module")
-def ca_model():
-    keep_models: bool = os.environ.get("KEEP_MODELS") is not None
-    with jubilant.temp_model(keep=keep_models) as juju:
+def ca_model(request):
+    with jubilant.temp_model(keep=_keep_models(request)) as juju:
         yield juju
 
 
 @pytest.fixture(scope="module")
-def cos_model():
-    keep_models: bool = os.environ.get("KEEP_MODELS") is not None
-    with jubilant.temp_model(keep=keep_models) as juju:
+def cos_model(request):
+    with jubilant.temp_model(keep=_keep_models(request)) as juju:
         yield juju
 
 

--- a/tests/integration/cos/tls_external/track-2.tf
+++ b/tests/integration/cos/tls_external/track-2.tf
@@ -44,7 +44,9 @@ module "ssc" {
 }
 
 module "cos" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/2"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/2"
+  depends_on = [module.ssc] # Ensure the CA model's offers exist before COS consumes them.
+
   model_uuid                      = data.juju_model.cos-model.uuid
   channel                         = "2/stable"
   internal_tls                    = false

--- a/tests/integration/cos/tls_external/track-3.0.tf
+++ b/tests/integration/cos/tls_external/track-3.0.tf
@@ -44,7 +44,9 @@ module "ssc" {
 }
 
 module "cos" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/3.0"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/3.0"
+  depends_on = [module.ssc] # Ensure the CA model's offers exist before COS consumes them.
+
   model                           = { uuid = data.juju_model.cos-model.uuid }
   risk                            = "edge"
   internal_tls                    = false

--- a/tests/integration/cos/tls_full/track-2.tf
+++ b/tests/integration/cos/tls_full/track-2.tf
@@ -44,7 +44,9 @@ module "ssc" {
 }
 
 module "cos" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/2"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/2"
+  depends_on = [module.ssc] # Ensure the CA model's offers exist before COS consumes them.
+
   model_uuid                      = data.juju_model.cos-model.uuid
   channel                         = "2/stable"
   internal_tls                    = true

--- a/tests/integration/cos/tls_full/track-3.0.tf
+++ b/tests/integration/cos/tls_full/track-3.0.tf
@@ -44,7 +44,9 @@ module "ssc" {
 }
 
 module "cos" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/3.0"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos?ref=track/3.0"
+  depends_on = [module.ssc] # Ensure the CA model's offers exist before COS consumes them.
+
   model                           = { uuid = data.juju_model.cos-model.uuid }
   risk                            = var.risk
   internal_tls                    = true

--- a/tests/integration/cos_lite/tls_external/track-2.tf
+++ b/tests/integration/cos_lite/tls_external/track-2.tf
@@ -32,7 +32,9 @@ module "ssc" {
 }
 
 module "cos-lite" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2"
+  depends_on = [module.ssc] # Ensure the CA model's offers exist before COS consumes them.
+
   model_uuid                      = data.juju_model.cos-model.uuid
   channel                         = "2/stable"
   internal_tls                    = false

--- a/tests/integration/cos_lite/tls_external/track-3.0.tf
+++ b/tests/integration/cos_lite/tls_external/track-3.0.tf
@@ -32,7 +32,9 @@ module "ssc" {
 }
 
 module "cos-lite" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/3.0"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/3.0"
+  depends_on = [module.ssc] # Ensure the CA model's offers exist before COS consumes them.
+
   model                           = { uuid = data.juju_model.cos-model.uuid }
   risk                            = "edge"
   internal_tls                    = false

--- a/tests/integration/cos_lite/tls_full/track-2.tf
+++ b/tests/integration/cos_lite/tls_full/track-2.tf
@@ -32,7 +32,9 @@ module "ssc" {
 }
 
 module "cos-lite" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/2"
+  depends_on = [module.ssc] # Ensure the CA model's offers exist before COS consumes them.
+
   model_uuid                      = data.juju_model.cos-model.uuid
   channel                         = "2/stable"
   internal_tls                    = true

--- a/tests/integration/cos_lite/tls_full/track-3.0.tf
+++ b/tests/integration/cos_lite/tls_full/track-3.0.tf
@@ -32,7 +32,9 @@ module "ssc" {
 }
 
 module "cos-lite" {
-  source                          = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/3.0"
+  source     = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=track/3.0"
+  depends_on = [module.ssc] # Ensure the CA model's offers exist before COS consumes them.
+
   model                           = { uuid = data.juju_model.cos-model.uuid }
   risk                            = var.risk
   internal_tls                    = true


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We need to backport this PR:
- https://github.com/canonical/observability-stack/pull/467

so we have support for Juju v4.

## Solution
<!-- A summary of the solution addressing the above issue -->
The referenced PR tests that track/dev deploys on Juju v4, while this PR tests that track/3.0 deploys on Juju v4. The backport was required to ensure that the CA module deployed before the COS module to avoid race conditions; see the original PR description for details.

### Checklist
- [ ] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
- [ ] This PR has Terraform product changes and appropriate [lifecycle args](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle) and [moved blocks](https://developer.hashicorp.com/terraform/language/block/moved) were added to the `terraform/*/upgrades.tf` file(s).
- [ ] This PR has breaking changes to the product API(s) and I have created an issue in [SolQA pipelines](https://github.com/canonical/terragrunt-deployment-pipelines) to address this.
